### PR TITLE
feat: item pickups, tire marks, spring UI, and review fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Port of the Kenney "Starter Kit Racing" Godot 4.6 project (in `_godot/`) to plai
 
 ## Key conventions
 
-- GridMap cell size: 9.99 units, scale: 0.75 (`CELL_RAW` and `GRID_SCALE` in `Track.js`)
+- GridMap cell size: 9.99 units, scale: 1.0 (`CELL_RAW` and `GRID_SCALE` in `Track.js`)
 - Track group has `position.y = -0.5` offset
 - Godot vehicle models use `root_scale = 0.5`
 - Wall colliders: friction 0.0, restitution 0.1

--- a/docs/brainstorms/2026-03-30-audio-game-feel-requirements.md
+++ b/docs/brainstorms/2026-03-30-audio-game-feel-requirements.md
@@ -1,0 +1,52 @@
+---
+date: 2026-03-30
+topic: audio-game-feel
+---
+
+# Audio-Driven Game Feel
+
+## Problem Frame
+
+The game has working file-based audio (engine, skid, impact) but collisions feel weightless — there's no visual feedback when hitting walls or other players. The engine sound is tied to an audio file that can't be tuned in real-time. Replacing the engine with procedural synthesis and adding camera shake transforms the moment-to-moment feel from "tech demo" to "game."
+
+## Requirements
+
+**Procedural Engine Audio**
+- R1. Replace the file-based engine sound (engine.ogg) with a Web Audio oscillator-based engine. Base frequency mapped to vehicle speed, volume to throttle.
+- R2. Engine sound has at least two oscillator layers (base + detuned overtone) for texture.
+- R3. Smooth transitions — no clicks or pops when speed changes. Use gain ramping and frequency lerping.
+- R4. Keep the existing skid.ogg and impact.ogg file-based sounds — only replace the engine loop.
+
+**Camera Shake**
+- R5. Camera shakes on wall/player collisions. Subtle and snappy — short burst (~0.2s), small position offset.
+- R6. Shake intensity is fixed (not proportional to speed) to keep it simple and consistent.
+- R7. Shake decays rapidly (exponential falloff) so it doesn't linger.
+
+## Success Criteria
+
+- Engine sound pitch rises and falls smoothly with speed, no audio file dependency.
+- Hitting a wall produces a visible camera jolt + the existing impact sound.
+- The game feels noticeably more alive with both changes combined.
+
+## Scope Boundaries
+
+- No changes to skid or impact audio — keep existing files.
+- No screen flash or post-processing effects on collision.
+- No per-vehicle audio differentiation (all vehicles sound the same).
+- No mobile vibration/haptics.
+
+## Key Decisions
+
+- **Replace engine.ogg, don't layer:** Simpler, zero asset dependency, fully tunable.
+- **Fixed shake intensity:** Avoids tuning complexity. One shake feel for all collisions.
+- **Keep skid + impact files:** They already work well; no reason to synthesize them.
+
+## Outstanding Questions
+
+### Deferred to Planning
+- [Affects R1][Needs research] Best oscillator waveform for a kart engine feel — sawtooth, triangle, or custom periodic wave?
+- [Affects R5][Technical] How to apply shake offset to Camera.js — direct position offset on the camera, or offset on the follow target?
+
+## Next Steps
+
+-> `/ce:plan` or directly to work

--- a/docs/brainstorms/2026-03-31-track-item-pickups-requirements.md
+++ b/docs/brainstorms/2026-03-31-track-item-pickups-requirements.md
@@ -1,0 +1,72 @@
+---
+date: 2026-03-31
+topic: track-item-pickups
+---
+
+# Track Item Pickups
+
+## Problem Frame
+
+Kart Kids has a race loop, drift mechanics, and boost system, but the track itself is inert — driving skill is the only variable. There are no interactive elements on the track surface to create moment-to-moment decisions or surprise. Self-use powerup pickups add strategic variety to racing lines without requiring AI opponents or offensive item mechanics.
+
+## Requirements
+
+**Item Box Placement**
+- R1. Item boxes are placed automatically at regular intervals along the TrackIntel waypoint chain (e.g., every 3rd waypoint). Works on any track including custom and future procedural tracks.
+- R2. Item boxes are rendered as visible 3D objects on the track surface (spinning box or floating cube, visually distinct from track geometry).
+- R3. Item boxes respawn on a ~10-second cooldown after being collected. They fade out on pickup and fade back in when available.
+
+**Pickup Behavior**
+- R4. Driving through an item box triggers an immediate self-use powerup effect — no inventory, no holding, no manual activation.
+- R5. Powerup type is selected randomly from a weighted table on each pickup.
+- R6. A brief visual + audio cue plays on pickup (particle burst, chime sound).
+
+**Powerup Types**
+- R7. **Speed Boost** (common, ~60% weight): Instant burst of speed equivalent to a stage-2 mini-boost. Uses the existing miniBoostTimer/miniBoostTopSpeed system.
+- R8. **Shield Bubble** (medium, ~30% weight): Absorbs the next wall collision without speed loss. Visual indicator (colored glow or bubble around kart). Lasts ~5 seconds or until a wall hit, whichever comes first.
+- R9. **Star / Invincibility** (rare, ~10% weight): Max speed + no wall collision speed penalty for ~3 seconds. Distinct visual (flashing kart or golden glow) and audio (ascending tone or jingle).
+
+**Multiplayer**
+- R10. In multiplayer, item box state (collected/available) is per-player — one player collecting a box does not affect others.
+- R11. Item box state syncs via the existing 20Hz WebSocket broadcast. Active powerup effects (shield glow, star flash) are visible on remote players.
+
+## Success Criteria
+
+- Solo player encounters 3-5 item boxes per lap on the default track
+- Each powerup type has a noticeable, distinct effect on gameplay
+- Picking up an item feels rewarding (audio + visual feedback)
+- Items don't break the existing drift/boost skill loop — they complement it
+
+## Scope Boundaries
+
+- No offensive items (projectiles, traps, etc.) — self-use only
+- No item inventory or manual activation — instant trigger on pickup
+- No editor placement — auto-placement only for v1
+- No position-based or drift-meter-based item weighting — pure random with fixed weights
+- Shield does not protect against falling off track
+
+## Key Decisions
+
+- **Self-use only:** No AI opponents exist yet. Self-use powerups provide value in both solo and multiplayer without requiring target selection or projectile physics.
+- **Random weighted tier:** Simplest implementation. Drift-meter gating or position-based weighting are future enhancements.
+- **Auto-placement via TrackIntel:** Ensures every track has items without requiring editor changes or manual placement data in track URLs.
+- **Per-player item state:** In multiplayer, boxes are independently available to each player. Avoids the complexity of shared-state item contention and ensures fairness.
+- **Instant trigger:** No inventory UI, no held-item display, no activation button. Reduces scope and keeps the controls simple.
+
+## Dependencies / Assumptions
+
+- TrackIntel waypoint chain is stable and available for all track configurations
+- Existing mini-boost system (miniBoostTimer, miniBoostTopSpeed) can be reused for Speed Boost powerup
+- Wall collision contact listener in main.js can be extended to check for active shield
+
+## Outstanding Questions
+
+### Deferred to Planning
+- [Affects R2][Needs research] What 3D representation works best for item boxes? Options: simple cube geometry, sprite, or GLB model. Consider performance with many boxes on track.
+- [Affects R3][Technical] How to implement per-box cooldown timer efficiently — per-box state array or pooled approach?
+- [Affects R8][Technical] How to suppress wall collision speed loss during shield — intercept in contactListener or in Vehicle.js?
+- [Affects R10][Technical] What minimal data needs to be added to the 20Hz network broadcast for item state sync?
+
+## Next Steps
+
+-> /ce:plan for structured implementation planning

--- a/docs/brainstorms/2026-03-31-visual-polish-pass-requirements.md
+++ b/docs/brainstorms/2026-03-31-visual-polish-pass-requirements.md
@@ -1,0 +1,58 @@
+---
+date: 2026-03-31
+topic: visual-polish-pass
+---
+
+# Visual Polish Pass: Tire Marks + Spring-Physics UI
+
+## Problem Frame
+
+Kart Kids has strong gameplay systems (drift, boost, items) but the visual presentation doesn't match. Drifting produces sparks but leaves no trace on the track. HUD elements appear and disappear instantly with no animation weight. These two features address the gap between gameplay depth and visual feedback quality.
+
+## Requirements
+
+**Tire Marks / Skid Decals**
+- R1. Rear wheels leave visible dark marks on the track surface during drifts (driftStage > 0) and heavy braking.
+- R2. Marks persist for the entire race, building up a visual record of the racing line.
+- R3. Mark width scales with drift intensity / slip angle — wider marks during harder drifts.
+- R4. Marks render as ribbon geometry extruded along the rear wheel ground contact path.
+- R5. Marks are visible for all players (local + remote) in multiplayer.
+- R6. All marks clear on race restart.
+
+**Spring-Physics UI**
+- R7. All HUD value changes animate with damped spring physics instead of instant/CSS easing.
+- R8. Affected elements: countdown numbers, lap counter, boost bar fill, powerup indicator, race time, race results.
+- R9. Spring magnitude responds to the size of the change — a 1st-to-5th position jump bounces harder than 3rd-to-4th.
+- R10. Spring parameters are consistent across all HUD elements (same stiffness/damping, different rest positions).
+
+## Success Criteria
+
+- Drifting around a corner leaves a visible trail on the track behind the kart
+- After 3 laps, the player can see their racing line drawn on the track
+- Every HUD number/bar change has a satisfying overshoot-settle animation
+- The polish feels cohesive, not noisy
+
+## Scope Boundaries
+
+- No tire marks on non-drift driving (normal straight-line driving)
+- No surface-type coloring for marks (all marks are dark gray/black for v1)
+- No per-player mark colors in multiplayer (all marks same color)
+- Spring UI is DOM-based CSS transforms, not canvas/WebGL rendering
+- No spring animations on non-HUD elements (menus, debug panel)
+
+## Key Decisions
+
+- **Persist whole race:** Marks stay until reset. Players see their line improve lap over lap. More geometry but bounded by race length.
+- **Spring everything:** Consistent spring feel across all HUD elements, not selective. The consistency IS the polish.
+- **Ribbon geometry for marks:** Not projected decals (too heavy in raw Three.js). Ribbon mesh extruded along wheel paths is cheaper and matches the existing VFX approach.
+
+## Outstanding Questions
+
+### Deferred to Planning
+- [Affects R4][Technical] Ring buffer size for ribbon geometry — how many segments before oldest start being overwritten? Or grow unbounded for a 3-lap race?
+- [Affects R5][Technical] Should remote player tire marks use their interpolated wheel positions, or skip remote marks for v1?
+- [Affects R7][Technical] Should spring state live in HUD.js or in a reusable SpringAnimator utility class?
+
+## Next Steps
+
+-> /ce:plan for structured implementation planning

--- a/docs/ideation/2026-03-31-open-v015-ideation.md
+++ b/docs/ideation/2026-03-31-open-v015-ideation.md
@@ -1,0 +1,99 @@
+---
+date: 2026-03-31
+topic: open-v015-ideation
+focus: open-ended post-v0.15 review
+---
+
+# Ideation: Post-v0.15 Open Ideation
+
+## Codebase Context
+
+- **Project shape:** Three.js + crashcat physics kart racer, 25 JS modules, no bundler, ES module importmap.
+- **v0.15 features:** Race state machine + HUD, WebSocket multiplayer (4 players), track editor, minimap, TrackIntel waypoints/progress, boost/nitro, drift stage machine (3 stages) with sparks, g-force camera (roll, FOV, distance, shake), wall sparks, boost burst/flame particles, haptics, race lobby, AFK detector, raycast ground detection, box collider vehicle, triangle mesh track colliders, instanced mesh rendering, mobile optimizations.
+- **Key gaps:** No AI opponents, no ghost replay, no items/pickups, no progression/career, no character differentiation, no leaderboards, no track validation in editor, no procedural tracks, limited audio (engine + impacts + whoosh + chime only).
+- **Past learnings:** Boost physics scales with topSpeed (set once, not every frame). Line-segment crossing for spatial triggers. Constructor injection + display state flow for module integration. Triangle mesh colliders from visual meshes risk phantom collisions.
+- **Open tech debt:** 5 deferred review items in tasks/todo.md (phantom collision risk, solo lobby start, window.isMobile global, haptics polling, audio spatial bypass).
+
+## Ranked Ideas
+
+### 1. Ghost Replay via Input Recording
+**Description:** Record per-frame inputs (steer, throttle, boost) during a race, replay as a transparent ghost kart. Store best laps in localStorage keyed by track hash. Encode replays as URL parameters alongside track data — a single link = track + ghost + time to beat.
+**Rationale:** Highest standalone value. Uses existing Vehicle remote-player interpolation path. ~16KB per 90s race. Zero server infrastructure. Inherently viral via URL sharing.
+**Downsides:** Requires deterministic-enough physics (may need fixed timestep later for perfect replay fidelity). Replay drift over long races.
+**Confidence:** 90%
+**Complexity:** Medium
+**Status:** Unexplored
+
+### 2. AI Opponents via TrackIntel Waypoints
+**Description:** AI drivers follow TrackIntel waypoint chain, producing inputX/inputZ/boost per frame. Difficulty via topSpeed and aggression scaling. Rubber-banding via progress delta.
+**Rationale:** Transforms the game from solo time trial into an actual race. TrackIntel already has ordered waypoints and progress %. PlayerManager already handles multiple vehicles.
+**Downsides:** Making AI feel fun (not robotic, not rubberbanding too obviously) is a tuning challenge. Ship dumb AI first.
+**Confidence:** 85%
+**Complexity:** Medium
+**Status:** Unexplored
+
+### 3. Kart Selection with Physics Profiles
+**Description:** 4 physics profiles (speed, drift, balanced, heavy) that override Vehicle.debug params per color variant. Pre-race selection screen with stat bars.
+**Rationale:** Near-zero implementation cost — just named presets over existing tuning params. Gives players identity and strategic track-dependent choices.
+**Downsides:** Balance across profiles needs playtesting. Selection UI is more work than the profiles themselves.
+**Confidence:** 90%
+**Complexity:** Low
+**Status:** Unexplored
+
+### 4. Track Hazards: Speed Pads & Jump Ramps
+**Description:** New cell types that modulate existing Vehicle params on contact — speed pad triggers mini-boost, jump ramp adds Y velocity. Oil slick zeroes grip temporarily.
+**Rationale:** Multiplies track design space using existing systems. Each hazard is just a temporary param override on a trigger zone. Massively improves the track editor.
+**Downsides:** Jump ramp interacts with the raycast ground system (needs careful Y handling). New 3D assets needed or use flat decals.
+**Confidence:** 80%
+**Complexity:** Medium
+**Status:** Unexplored
+
+### 5. Track Items/Pickups at Waypoint Positions
+**Description:** Item boxes placed at TrackIntel waypoint positions. Pickup triggers existing systems (boost, shield, speed burst). Item tier could vary by drift meter or position. Multiplayer sync via existing 20Hz WebSocket state broadcast.
+**Rationale:** Highest leverage — touches VFX, audio, HUD, haptics, multiplayer, and TrackIntel in one feature. Pairs naturally with hazards (#4).
+**Downsides:** Item interactions with boost system need deconfliction. Item art needed. Multiplayer sync adds complexity.
+**Confidence:** 80%
+**Complexity:** Medium-High
+**Status:** Explored
+
+### 6. Procedural Track Generation
+**Description:** Random walk through TrackIntel's connectivity grammar with loop-closure constraint. Seed-based generation shareable via `?seed=12345`.
+**Rationale:** Infinite replayability from existing infrastructure. TrackIntel BASE_CONNECTIVITY is literally a formal grammar for valid tracks. Combined with ghosts, creates an endless content loop.
+**Downsides:** Valid tracks != fun tracks. Needs constraints on minimum length, corner distribution, etc.
+**Confidence:** 75%
+**Complexity:** Medium
+**Status:** Unexplored
+
+### 7. Reactive Layered Music System
+**Description:** Pre-composed stems (bass, percussion, melody) crossfade based on speed, drift stage, boost state. Uses existing Web Audio GainNode pattern from Audio.js.
+**Rationale:** Pure juice. Audio.js already demonstrates reactive volume/pitch. Drift 3-stage system is begging for escalating musical tension.
+**Downsides:** Needs good layered audio assets. The music itself is the hard part, not the code.
+**Confidence:** 70%
+**Complexity:** Low (code) / Medium (assets)
+**Status:** Unexplored
+
+## Rejection Summary
+
+| # | Idea | Reason Rejected |
+|---|------|-----------------|
+| 1 | Spectator Cinematic Director | No audience to spectate an indie kart racer |
+| 2 | Play-to-Build Track Editor | Edge cases (branching, corrections) worse than grid editor |
+| 3 | Editor-First UX Pivot | Product strategy pivot, not a feature at v0.15 |
+| 4 | Deterministic Physics Timestep | Premature infra — no replay validation needs it yet |
+| 5 | Replace Triangle Mesh Colliders | Speculative rewrite — fix specific bugs instead |
+| 6 | Vertical Tracks (Y axis) | 3+ week feature touching every system; jump ramp is cheaper |
+| 7 | WebRTC P2P Multiplayer | Infra rewrite with zero player-facing improvement |
+| 8 | Positional Audio for Remotes | Weak payoff on tight circuit with 4 players |
+| 9 | Schema-Driven Debug Panel | Premature DX infra for solo dev |
+| 10 | Split main.js | Housekeeping, not gameplay — do when it causes pain |
+| 11 | Module Self-Registration Kernel | Framework-building, not game-building |
+| 12 | Merge GLB Models | Micro-optimization — add loading screen instead |
+| 13 | Headless Physics Tuning | Can't gradient-descend toward fun |
+| 14 | Tag/Chase Game Mode | Needs kart-to-kart collision (risky prerequisite) |
+| 15 | Kart-to-Kart Collision | High impact but collision response in crashcat is genuinely hard |
+| 16 | Leaderboards | Companion to ghost replay, not standalone |
+| 17 | Track Editor Validation | Useful but low impact vs gameplay features |
+
+## Session Log
+- 2026-03-31: Fresh open-ended ideation post-v0.15 — 39 raw ideas from 5 agents, 24 after dedupe, 7 survived adversarial filtering
+- 2026-03-31: Brainstormed idea #5 (Track Items/Pickups) — requirements doc at docs/brainstorms/2026-03-31-track-item-pickups-requirements.md

--- a/docs/ideation/2026-03-31-open-v015-round2-ideation.md
+++ b/docs/ideation/2026-03-31-open-v015-round2-ideation.md
@@ -1,0 +1,173 @@
+---
+date: 2026-03-31
+topic: open-v015-round2
+focus: open-ended post-items, fresh angles (experience, browser-native, visual, gameplay, wild)
+---
+
+# Ideation: Post-Items Open Ideation (Round 2)
+
+## Codebase Context
+
+- **v0.15+ with items:** Everything from round 1 plus ItemBoxManager (speed boost/shield/star), ItemPickupVFX, shield/star wall interception, HUD powerup indicator, multiplayer powerup sync.
+- **Key systems:** crashcat physics with raycast ground, drift state machine (3 stages), boost/nitro, g-force camera, 5 particle systems, TrackIntel waypoints, race state machine, WebSocket multiplayer, track editor, mobile support.
+
+## Ranked Ideas
+
+### Tier 1 — Quick Wins
+
+### 1. Finish Line Slow-Mo with Radial Blur
+**Description:** When crossing the finish on the final lap, time scales to 0.2x for 2 seconds. Radial zoom blur post-process centered on the kart. Camera auto-orbits to a hero shot. Confetti burst. Time resumes, results slide in.
+**Rationale:** The emotional peak of every race currently just... stops. A 3-second slow-mo transforms a boolean into a memory. Trivial dt multiplier + simple shader.
+**Downsides:** Radial blur shader needs mobile testing.
+**Confidence:** 90%
+**Complexity:** Low
+**Status:** Unexplored
+
+### 2. Brake-Drift Cancel
+**Description:** Tap brake during an active drift (stage >= 1) to instantly cancel the drift with zero mini-boost reward BUT preserve 90% of current speed. Creates a technique for chaining rapid direction changes at higher average speed than holding a single long drift.
+**Rationale:** Adds an advanced technique layer without changing how drift works for beginners. One input check in the existing drift state machine. Pure depth, zero new systems.
+**Downsides:** May be too subtle for casual players to discover. Needs a visual/audio cue on cancel.
+**Confidence:** 85%
+**Complexity:** Low
+**Status:** Unexplored
+
+### 3. Slope Slingshot
+**Description:** When the vehicle transitions from a downhill slope to flat (rapid change in groundNormal.y), grant a speed burst proportional to entry speed and slope steepness.
+**Rationale:** Creates momentum puzzles where players choose between safe flat lines or risky slope dips. groundNormal transition detection already exists in Vehicle.js.
+**Downsides:** Only matters on tracks with elevation changes (bump tiles). Limited on flat tracks.
+**Confidence:** 85%
+**Complexity:** Low
+**Status:** Unexplored
+
+### 4. Spring-Physics UI Animations
+**Description:** All HUD elements use damped spring animations instead of CSS easing. Position counter bounces on change, lap counter overshoots and settles, countdown numbers spring in. A 20-line damped harmonic oscillator driving CSS transforms.
+**Rationale:** Spring physics feel alive — they respond to magnitude. The difference between a UI that displays information and one that communicates emotion.
+**Downsides:** Minimal. May need to cap spring overshoot for readability.
+**Confidence:** 90%
+**Complexity:** Low
+**Status:** Unexplored
+
+### 5. Session Streaks + Daily Track
+**Description:** localStorage tracks consecutive-day play streaks. Each day, a seeded "Daily Track" generates from a date hash. Streaks unlock cosmetic trail colors.
+**Rationale:** Zero reason to come back tomorrow right now. A daily challenge is the lowest-friction retention hook. No accounts needed.
+**Downsides:** Needs procedural track generation to work (or a curated track list). Trail color unlocks need VFX work.
+**Confidence:** 75%
+**Complexity:** Low-Medium
+**Status:** Unexplored
+
+### Tier 2 — Core Gameplay Depth
+
+### 6. Surface Material Physics
+**Description:** Tag track tiles with surface types (asphalt, grass, ice, sand). Different surfaces modify grip, speed, and drift fill rate. Grass shortcuts trade speed for faster boost charging.
+**Rationale:** Explodes the decision space for every corner. Optimal racing line depends on boost meter, drift stage, and race position.
+**Downsides:** Needs new tile visuals or at least color-coded overlays. Balance across surfaces requires tuning.
+**Confidence:** 80%
+**Complexity:** Medium
+**Status:** Unexplored
+
+### 7. Couch Co-op Split Screen
+**Description:** 2-player local split screen — left/right viewports, WASD vs arrows. Reuse Vehicle, Camera, Controls as second instances with viewport scissor.
+**Rationale:** Doubles audience. Most common "show a friend" scenario. Rare for browser games.
+**Downsides:** Input routing, two physics bodies, two cameras. Performance on mobile is questionable.
+**Confidence:** 80%
+**Complexity:** Medium
+**Status:** Unexplored
+
+### 8. Wall-Ride Momentum Transfer
+**Description:** Shallow-angle wall scrapes convert a percentage of wall-normal impulse into forward speed. Sustained contact builds a "grind spark" and small speed multiplier. Too steep = full speed loss as today.
+**Rationale:** Turns every wall from pure punishment into risk/reward. Creates a distinct high-skill racing line.
+**Downsides:** Tuning the angle threshold is critical. Too generous = walls become speed boosts.
+**Confidence:** 80%
+**Complexity:** Medium
+**Status:** Unexplored
+
+### 9. Tire Marks / Skid Decals
+**Description:** Persistent ribbon geometry extruded along rear wheels during drifts and heavy braking. Opacity fade based on age, color by surface type, width by slip angle. Ring buffer of ~2000 segments per kart.
+**Rationale:** Archaeological evidence of driving. See your own racing line improving lap over lap. Every serious racing game has them.
+**Downsides:** Ribbon geometry management needs care. Memory bounded by ring buffer.
+**Confidence:** 85%
+**Complexity:** Medium
+**Status:** Unexplored
+
+### 10. First-Lap Tutorial Ghost
+**Description:** On first-ever race, spawn a translucent coach kart following TrackIntel waypoints at 80% speed. Fades out after lap 1. No UI, no text — just follow.
+**Rationale:** Game drops you in with no onboarding. A wordless demonstration teaches track, drift, and boost.
+**Downsides:** Needs ghost rendering infrastructure (which also serves ghost replay later).
+**Confidence:** 85%
+**Complexity:** Medium
+**Status:** Unexplored
+
+### 11. Progressive Difficulty Curve
+**Description:** Track best times in localStorage. First session is 2 laps, pure racing. Later sessions add items, then all mechanics. Gradually ramp complexity.
+**Rationale:** Currently dumps full system on new players. Config gating, not new code.
+**Downsides:** May frustrate returning players who want everything immediately. Needs an override.
+**Confidence:** 75%
+**Complexity:** Low
+**Status:** Unexplored
+
+### Tier 3 — Polish and Social
+
+### 12. Web Speech Commentator
+**Description:** speechSynthesis API narrates race events live. "And they take the lead!" "Last lap!" Template engine fed by race events. Players pick from system voices for different commentator personalities.
+**Rationale:** Zero-asset audio content. System TTS in a kart game is absurd and charming. ~50 lines.
+**Downsides:** TTS quality varies by OS. May sound bad on some devices.
+**Confidence:** 75%
+**Complexity:** Low
+**Status:** Unexplored
+
+### 13. Share-to-Challenge Links
+**Description:** Ghost replay serialized into a URL. Click link = race against their ghost on their track. Web Share API on mobile.
+**Rationale:** "Beat my time" as a single link. Viral loop with zero server.
+**Downsides:** URL length limits. Needs compression for longer replays.
+**Confidence:** 80%
+**Complexity:** Medium
+**Status:** Unexplored
+
+### 14. Clipboard Track Sharing
+**Description:** Copy a compact track code + ASCII art preview to clipboard. Paste in Discord, forums. Detect paste on focus to offer loading.
+**Rationale:** URLs get mangled by platforms. Short codes work everywhere text works.
+**Downsides:** ASCII preview is a nice-to-have, not essential. Core is just a code.
+**Confidence:** 85%
+**Complexity:** Low
+**Status:** Unexplored
+
+### 15. Cinematic Race Intro Flythrough
+**Description:** Before countdown, a 4-6 second camera sequence: wide establishing shot, quick cuts to key corners, dolly-zoom onto starting grid. CatmullRomCurve3 camera path. Letterbox bars.
+**Rationale:** First impressions define perceived quality. Also teaches track layout subconsciously.
+**Downsides:** Adds 4-6 seconds before racing starts. Needs a skip option.
+**Confidence:** 85%
+**Complexity:** Low-Medium
+**Status:** Unexplored
+
+## Rejection Summary
+
+| # | Idea | Reason Rejected |
+|---|------|-----------------|
+| 1 | Instant Clip Share | WebCodecs patchy, encoding perf tanks on low-end |
+| 2 | Persistent Kart Garage | Asset production trap for solo dev |
+| 3 | Race Link (One-Click Invite) | Multiplayer networking project disguised as URL feature |
+| 4 | End-of-Race Replay Theater | Camera cut system for a 15s moment nobody watches twice |
+| 5 | Voice Taunt Channel | WebRTC for 2s audio bursts — absurd infra:fun ratio |
+| 6 | DeviceMotion Steering | Calibration hell, gimmick that demos well and ships never |
+| 7 | Notification Async Tournaments | Push notifications require service worker + backend |
+| 8 | iframe Spectator Embed | Zero audience for embedded kart races in blog posts |
+| 9 | Cross-Device Handoff | Multiplayer sync with extra steps |
+| 10 | Heat Haze Distortion | Custom post-process pass, framerate risk for subtle effect |
+| 11 | Dynamic Rain/Puddles | Three features stapled together, each nontrivial |
+| 12 | Track-Side Animated Props | Asset-bound, not code-bound |
+| 13 | Chromatic Aberration | "I watched a Unity tutorial" energy, annoys visual sensitivity |
+| 14 | Drafting/Slipstream | Needs AI close enough to draft against; multiplayer-only value |
+| 15 | Airborne Trick System | Sub-game requiring ramps, animations, landing validation |
+| 16 | Surface Material Physics | KEPT (Tier 2) |
+| 17 | Momentum Banking | Punishes going fast — counterintuitive in a racing game |
+| 18 | G-Force Drift Catalyst | Muddies the input language; one drift system is enough |
+| 19 | Track Painter | Standalone project, not a feature |
+| 20 | Crowd-Possessed Kart | Studio scope, not solo dev |
+| 21 | Selfie Karts | Uncanny valley on a 3D mesh |
+| 22 | Soundtrack Fusion | BPM analysis unreliable, mapping feels random |
+| 23 | Quantum Split | Two physics sims for a gimmick that confuses players |
+| 24 | Graffiti Warfare | Per-texel tracking + balance = different game |
+| 25 | Architect Mode | Three hard problems at once |
+
+## Session Log
+- 2026-03-31: Round 2 open-ended ideation — 39 raw ideas from 5 agents (experience, browser-native, visual, emergent, wild), 15 survived adversarial filtering

--- a/docs/plans/2026-03-30-002-feat-audio-game-feel-plan.md
+++ b/docs/plans/2026-03-30-002-feat-audio-game-feel-plan.md
@@ -1,0 +1,150 @@
+---
+title: "feat: Procedural engine audio and camera shake on collision"
+type: feat
+status: active
+date: 2026-03-30
+origin: docs/brainstorms/2026-03-30-audio-game-feel-requirements.md
+---
+
+# feat: Procedural Engine Audio + Camera Shake
+
+## Overview
+
+Replace the file-based engine sound with Web Audio oscillators mapped to vehicle speed, and add camera shake on collisions. Both changes target moment-to-moment game feel.
+
+## Problem Frame
+
+Collisions feel weightless (no visual feedback) and the engine sound can't be tuned in real-time. (see origin: docs/brainstorms/2026-03-30-audio-game-feel-requirements.md)
+
+## Requirements Trace
+
+- R1. Procedural engine via Web Audio oscillators, frequency mapped to speed, volume to throttle
+- R2. Two oscillator layers (base + detuned overtone)
+- R3. Smooth transitions — no clicks/pops, use gain ramping and frequency lerping
+- R4. Keep skid.ogg and impact.ogg unchanged
+- R5. Camera shake on collision — subtle, snappy, ~0.2s burst
+- R6. Fixed shake intensity (not speed-proportional)
+- R7. Rapid exponential decay
+
+## Scope Boundaries
+
+- No changes to skid or impact audio
+- No screen flash or post-processing on collision
+- No per-vehicle audio differentiation
+- No mobile haptics
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Audio.js** — `GameAudio` class. `init(camera)` creates `THREE.AudioListener`, loads engine/skid/impact files. `update(dt, speed, throttle, driftIntensity)` lerps volume/pitch. `playBeep()` already demonstrates raw Web Audio oscillator creation via `listener.context`. The engine sound uses `THREE.Audio` with `setBuffer/setLoop/setVolume/setPlaybackRate`.
+- **Camera.js** — `Camera` class. `update(dt, target, vehicleQuaternion)` sets `this.camera.position` via `copy()` each frame in chase mode. Position is overwritten every frame — safe to add a temporary offset after the normal position computation.
+- **main.js:contactListener** — `onContactAdded(bodyA, bodyB)` fires on physics collisions, already computes `impactVelocity` and calls `audio.playImpact()`. This is the integration point for camera shake.
+
+### Institutional Learnings
+
+None — no `docs/solutions/` exists.
+
+## Key Technical Decisions
+
+- **Sawtooth + triangle waveforms:** Sawtooth for the base oscillator (rich harmonics, engine-like buzz). Triangle for the detuned overtone (smoother, adds body without harshness). Both are natively supported by `OscillatorNode.type`.
+- **Direct camera position offset for shake:** After `Camera.update()` computes the normal position, add a small random XYZ offset that decays exponentially. The camera position is recomputed from scratch each frame, so the offset never accumulates.
+- **Replace engine THREE.Audio, keep oscillators on listener.context:** Remove the `engine.ogg` loader and `THREE.Audio` for engine. Create two `OscillatorNode`s connected through `GainNode`s to `listener.context.destination`. This matches the pattern already used in `playBeep()`.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Oscillator waveform (R1):** Sawtooth base + triangle overtone. Sawtooth has the harmonic richness of an engine; triangle adds warmth without harshness.
+- **Camera shake integration (R5):** Direct position offset on `this.camera.position` after the normal update. Applied in Camera.js via a `shake(intensity)` method and per-frame decay in `update()`.
+
+### Deferred to Implementation
+
+- **Exact frequency range:** Start with 80-400Hz for base, 160-800Hz for overtone. Tune by ear during testing.
+- **Exact shake offset magnitude:** Start with 0.08 units. Tune visually.
+
+## Implementation Units
+
+- [ ] **Unit 1: Procedural Engine Audio**
+
+  **Goal:** Replace engine.ogg with two Web Audio oscillators that respond to vehicle speed and throttle.
+
+  **Requirements:** R1, R2, R3, R4
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `js/Audio.js`
+
+  **Approach:**
+  - Remove the `engine.ogg` loader and `this.engineSound` (`THREE.Audio` instance)
+  - In `init()`, after creating the listener, create two `OscillatorNode`s (sawtooth + triangle) each routed through a `GainNode` to `listener.context.destination`
+  - Store references to oscillators and gains as instance properties
+  - Start oscillators with gain at 0 (silent until audio context unlocked)
+  - In `update()`, replace the engine pitch/volume section: lerp oscillator frequencies toward target based on `speedFactor`, lerp gain toward target based on `throttleFactor`
+  - Use `setTargetAtTime` or direct value assignment with lerping for smooth transitions (no clicks)
+  - Detune the second oscillator by ~7 cents for natural texture
+  - Keep `checkReady()` — but now only check skid buffer (engine no longer needs a buffer)
+  - Keep `startSounds()` — start oscillators when audio unlocks, start skid loop as before
+
+  **Patterns to follow:**
+  - `playBeep()` in Audio.js for raw Web Audio oscillator creation pattern
+  - Existing `update()` lerping pattern for smooth transitions
+
+  **Test scenarios:**
+  - Happy path: At speed=0, engine oscillators are near-silent (gain ~0). At speed=1, frequency is at upper range and gain is audible.
+  - Happy path: Throttle input increases gain smoothly, releasing throttle decreases gain smoothly.
+  - Edge case: Audio context suspended (not yet unlocked) — oscillators created but silent, no errors thrown.
+  - Edge case: Speed changes rapidly (dt spike) — frequency lerps smoothly, no audible clicks.
+
+  **Verification:**
+  - Drive the kart. Engine sound pitch rises with speed, falls when braking. No clicks or pops. Skid and impact sounds still work.
+
+- [ ] **Unit 2: Camera Shake on Collision**
+
+  **Goal:** Add a short, snappy camera shake when the vehicle hits a wall or another player.
+
+  **Requirements:** R5, R6, R7
+
+  **Dependencies:** None (independent of Unit 1)
+
+  **Files:**
+  - Modify: `js/Camera.js`
+  - Modify: `js/main.js`
+
+  **Approach:**
+  - Add shake state to Camera: `_shakeIntensity` (float, starts at 0), `_shakeDecay` (constant, ~12-15 for fast exponential falloff)
+  - Add `shake(intensity)` method that sets `_shakeIntensity = intensity`
+  - In `update()`, after computing the final camera position, apply a random offset: `camera.position.x += (Math.random() - 0.5) * _shakeIntensity` (same for y and z). Then decay: `_shakeIntensity *= Math.exp(-_shakeDecay * dt)`
+  - In `main.js`, inside `contactListener.onContactAdded`, after `audio.playImpact()`, call `cam.shake(0.08)`
+
+  **Patterns to follow:**
+  - `contactListener.onContactAdded` in main.js for the collision hook
+  - Camera.update() position computation pattern
+
+  **Test scenarios:**
+  - Happy path: Hit a wall → camera jitters briefly → returns to smooth follow within ~0.2s.
+  - Happy path: No collision → no shake, camera follows smoothly as before.
+  - Edge case: Multiple rapid collisions → shake intensities don't stack unboundedly (each `shake()` call resets to the fixed intensity, doesn't add).
+  - Edge case: Shake during spectator or isometric mode — offset still applies to camera.position.
+
+  **Verification:**
+  - Drive into a wall. See a brief camera jolt. Camera returns to normal quickly. Feels snappy, not nauseating.
+
+## System-Wide Impact
+
+- **Interaction graph:** Audio.js engine section is fully replaced; skid and impact paths unchanged. Camera.js gains shake state. main.js contactListener gains one additional call.
+- **Unchanged invariants:** Skid audio, impact audio, camera follow behavior (aside from brief shake offset), all other game systems.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Oscillator engine sounds harsh or buzzy | Tune frequency range and gain curves during implementation. Can always revert to engine.ogg by restoring the loader. |
+| Camera shake feels too much or too little | Single constant (0.08) — easy to tune. |
+| Audio context timing issues with oscillator start | Match existing `playBeep()` pattern which already handles this. |
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-03-30-audio-game-feel-requirements.md](docs/brainstorms/2026-03-30-audio-game-feel-requirements.md)
+- Related code: `js/Audio.js`, `js/Camera.js`, `js/main.js:contactListener`

--- a/docs/plans/2026-03-31-003-feat-track-item-pickups-plan.md
+++ b/docs/plans/2026-03-31-003-feat-track-item-pickups-plan.md
@@ -1,0 +1,333 @@
+---
+title: "feat: Add track item pickups with self-use powerups"
+type: feat
+status: completed
+date: 2026-03-31
+origin: docs/brainstorms/2026-03-31-track-item-pickups-requirements.md
+---
+
+# feat: Add track item pickups with self-use powerups
+
+## Overview
+
+Add collectable item boxes distributed along the track that grant immediate self-use powerups: Speed Boost (common), Shield Bubble (medium), and Star/Invincibility (rare). Items auto-place via TrackIntel, trigger on drive-through, and respawn on a 10-second cooldown.
+
+## Problem Frame
+
+The track surface is inert — driving skill is the only variable. Self-use powerup pickups add moment-to-moment decisions about racing lines and create surprise/delight without requiring AI opponents or offensive item mechanics. (see origin: docs/brainstorms/2026-03-31-track-item-pickups-requirements.md)
+
+## Requirements Trace
+
+- R1. Item boxes auto-placed at regular intervals along TrackIntel waypoint chain
+- R2. Item boxes rendered as visible 3D objects on the track
+- R3. Boxes respawn on ~10s cooldown with fade-out/fade-in
+- R4. Driving through a box triggers an immediate powerup — no inventory
+- R5. Powerup type selected randomly from weighted table
+- R6. Visual + audio feedback on pickup
+- R7. Speed Boost (60%): instant mini-boost via existing miniBoostTimer system
+- R8. Shield Bubble (30%): absorbs next wall collision, lasts ~5s or until hit
+- R9. Star/Invincibility (10%): max speed + no wall penalty for ~3s
+- R10. Per-player item state in multiplayer
+- R11. Powerup effects visible on remote players
+
+## Scope Boundaries
+
+- No offensive items — self-use only
+- No item inventory or manual activation
+- No editor placement — auto-placement only
+- No position-based or drift-meter-based weighting — fixed random weights
+- Shield does not protect against falling off track
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **TrackIntel.getDistributedPositions(count)** — Returns evenly-spaced `{ x, z, forward }` positions along the track loop. Ideal for item placement. Already exists and is tested.
+- **Vehicle.miniBoostTimer / miniBoostTopSpeed** — Existing mini-boost system with automatic `effectiveTopSpeed` integration. Speed Boost powerup can set these directly.
+- **Vehicle.effectiveTopSpeed** — `Math.max(base, nitro, miniBoost)` — already handles multiple speed sources.
+- **contactListener.onContactAdded (main.js:966)** — Wall impact handler. Shield interception inserts a guard before the impact effects.
+- **Sprite pool pattern (WallSparks, BoostBurst)** — Pre-allocated sprite pool with ring buffer emit, per-frame update with life/velocity/fade. Follow BoostBurst for pickup burst VFX.
+- **HUD display state pattern** — `raceMode.getDisplayState()` returns an object consumed by `hud.update()`. Extend with powerup fields.
+- **Per-player VFX pattern (DriftSparks, BoostFlame)** — One instance per player entry in PlayerManager, updated in the per-player loop.
+
+### Institutional Learnings
+
+- Boost physics should not mutate `debug.topSpeed` directly — use `effectiveTopSpeed` / `miniBoostTimer` instead.
+- Constructor injection + display state flow is the established module integration pattern.
+
+## Key Technical Decisions
+
+- **Distance-based overlap for pickup detection, not physics contacts:** Item boxes don't need rigid bodies. A simple XZ distance check per frame (~5-8 boxes) is cheaper and avoids polluting the crashcat contact listener with non-wall contacts.
+- **Reuse miniBoostTimer for Speed Boost:** The existing `effectiveTopSpeed = Math.max(base, nitro, miniBoost)` formula already handles this. No new speed override system needed.
+- **New Vehicle fields for shield/star state:** `vehicle.shieldActive`, `vehicle.shieldTimer`, `vehicle.starActive`, `vehicle.starTimer`. These are simple boolean+timer pairs decremented in Vehicle.update().
+- **ItemBoxManager as a scene-level system:** Single instance created in main.js, updated in the game loop. Manages box meshes, respawn timers, and pickup detection. Follows the same pattern as WallSparks/BoostBurst (scene-level, not per-player).
+- **Simple cube geometry for item boxes:** Rotating `THREE.BoxGeometry` with emissive material. No GLB model needed for v1 — keeps it simple and avoids asset pipeline work.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **How to place item boxes at consistent intervals?** Use `TrackIntel.getDistributedPositions(N)` which already interpolates evenly along cumulative arc-length. Solves clustering on short segments.
+- **How to handle Y position of item boxes?** Place at a fixed height above the track group Y offset. The track is mostly flat (GRID_SCALE=1.0, trackGroup.position.y=-0.5), so a constant Y works for v1. Ramps/bumps may need raycast placement later.
+- **Where in the game loop to check pickups?** After `playerManager.update()` (step 4) and before boost feedback (step 5). This ensures vehicle positions are current before overlap checks.
+
+### Deferred to Implementation
+
+- **Exact respawn fade animation curve:** Linear opacity fade is sufficient; tune during implementation.
+- **Shield visual representation:** Could be a semi-transparent sphere mesh parented to vehicle container, or a color tint on the vehicle material. Decide during Unit 3 based on what looks best.
+- **Star visual representation:** Flashing emissive material or golden color tint. Decide during Unit 3.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification.*
+
+```
+Item Pickup Flow:
+
+  TrackIntel.getDistributedPositions(N)
+         │
+         ▼
+  ItemBoxManager (scene-level)
+  ├── boxes[]: { mesh, position, available, cooldownTimer }
+  ├── update(dt, activeVehicles)
+  │   ├── For each box: decrement cooldownTimer, fade in when ready
+  │   └── For each vehicle × each available box:
+  │       └── if XZ distance < pickupRadius:
+  │           ├── Roll weighted random → powerupType
+  │           ├── Apply powerup to vehicle (speed/shield/star)
+  │           ├── Emit pickup VFX + audio
+  │           └── Set box.available = false, start cooldown
+  └── dispose()
+
+Powerup State (on Vehicle):
+  shieldActive: bool, shieldTimer: float  → checked in contactListener
+  starActive: bool, starTimer: float      → checked in contactListener + effectiveTopSpeed
+  miniBoostTimer: float (existing)        → reused for Speed Boost
+
+Display State Extension:
+  raceMode.getDisplayState() adds:
+    shieldActive, starActive → consumed by HUD for indicator
+```
+
+## Implementation Units
+
+- [x] **Unit 1: ItemBoxManager — placement, rendering, respawn**
+
+  **Goal:** Create and render item boxes at evenly-distributed positions along the track. Handle respawn cooldown with fade-out/fade-in.
+
+  **Requirements:** R1, R2, R3
+
+  **Dependencies:** None
+
+  **Files:**
+  - Create: `js/ItemBoxManager.js`
+  - Modify: `js/main.js` (instantiate, wire into game loop)
+
+  **Approach:**
+  - Call `trackIntel.getDistributedPositions(N)` to get world positions. N = `Math.floor(trackIntel.count / 3)` (every ~3 cells).
+  - For each position, create a small `BoxGeometry` mesh with emissive material, spinning via `rotation.y += dt * 2`.
+  - Track per-box state: `{ mesh, available: true, cooldownTimer: 0 }`.
+  - On pickup (Unit 2): set `available = false`, `cooldownTimer = 10`, fade mesh opacity to 0.
+  - Each frame: decrement timer, when timer hits 0 set `available = true`, fade opacity back to 1.
+  - Y position: place at `trackGroup.position.y + 1.5` (floating above track surface).
+
+  **Patterns to follow:**
+  - WallSparks constructor pattern for mesh creation and scene attachment.
+  - BoostBurst `dispose()` pattern for cleanup.
+
+  **Test scenarios:**
+  - Happy path: ItemBoxManager creates N meshes at distinct world positions when constructed with TrackIntel
+  - Happy path: Box mesh rotates each frame when update() is called
+  - Edge case: Track with only 3 cells still places at least 1 item box
+  - Happy path: After pickup, box becomes unavailable and cooldown timer starts at 10s
+  - Happy path: After 10s cooldown, box becomes available again
+
+  **Verification:**
+  - Item boxes visible on track, floating and spinning. Picking one up (Unit 2) causes it to disappear and reappear after ~10 seconds.
+
+- [x] **Unit 2: Pickup detection and powerup application**
+
+  **Goal:** Detect when a vehicle drives through an available item box. Roll a weighted random powerup and apply its effect to the vehicle.
+
+  **Requirements:** R4, R5, R7, R8, R9
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Modify: `js/ItemBoxManager.js` (add pickup check in update)
+  - Modify: `js/Vehicle.js` (add shieldActive/Timer, starActive/Timer fields, decrement in update)
+
+  **Approach:**
+  - In `ItemBoxManager.update(dt, activeVehicles)`, for each available box, check XZ distance to each vehicle's `spherePos`. Pickup radius ~1.5 units.
+  - On overlap: roll random `Math.random()` against weights (0-0.6 = speed, 0.6-0.9 = shield, 0.9-1.0 = star).
+  - **Speed Boost:** Set `vehicle.miniBoostTimer = 2.0`, `vehicle.miniBoostTopSpeed = 300`. Reuses existing effectiveTopSpeed math.
+  - **Shield:** Set `vehicle.shieldActive = true`, `vehicle.shieldTimer = 5.0`. Vehicle.update decrements timer and clears flag when expired.
+  - **Star:** Set `vehicle.starActive = true`, `vehicle.starTimer = 3.0`. Vehicle.update decrements timer. While active, `effectiveTopSpeed` includes star speed (350). ContactListener skips wall penalty.
+  - Add new Vehicle fields in constructor: `shieldActive = false`, `shieldTimer = 0`, `starActive = false`, `starTimer = 0`.
+  - Add timer decrement block in Vehicle.update() after the boost/drift section.
+
+  **Patterns to follow:**
+  - Vehicle.miniBoostTimer decrement pattern (Vehicle.js lines 619-631).
+  - effectiveTopSpeed Math.max pattern (Vehicle.js line 676).
+
+  **Test scenarios:**
+  - Happy path: Vehicle within 1.5 units of available box triggers pickup
+  - Happy path: Speed Boost sets miniBoostTimer and miniBoostTopSpeed on vehicle
+  - Happy path: Shield sets shieldActive = true and shieldTimer = 5.0
+  - Happy path: Star sets starActive = true and starTimer = 3.0
+  - Edge case: Vehicle outside pickup radius does not trigger pickup
+  - Edge case: Unavailable box (on cooldown) does not trigger pickup
+  - Happy path: Shield timer decrements and clears shieldActive when expired
+  - Happy path: Star timer decrements and clears starActive when expired
+  - Happy path: Star active adds star speed to effectiveTopSpeed calculation
+
+  **Verification:**
+  - Driving through a box applies one of the three powerup effects. Speed boost is noticeably faster. Shield/star timers count down and expire.
+
+- [x] **Unit 3: Shield and star wall-collision interception**
+
+  **Goal:** Shield absorbs the next wall hit without speed loss. Star prevents all wall collision penalties during its duration.
+
+  **Requirements:** R8, R9
+
+  **Dependencies:** Unit 2
+
+  **Files:**
+  - Modify: `js/main.js` (contactListener.onContactAdded guard)
+
+  **Approach:**
+  - At the top of `contactListener.onContactAdded`, after the `vehicle.rigidBody` check and before the ground-contact filter:
+    - If `vehicle.starActive`: return early (no impact effects at all).
+    - If `vehicle.shieldActive`: set `vehicle.shieldActive = false`, `vehicle.shieldTimer = 0`, play a shield-break sound, return early (no speed loss, no sparks, no shake).
+  - Star does not consume itself on hit — it lasts the full 3 seconds regardless of wall contacts.
+
+  **Patterns to follow:**
+  - Existing early-return guards in contactListener (ground filter, speed filter, cooldown).
+
+  **Test scenarios:**
+  - Happy path: With shield active, wall hit clears shield but produces no sparks/shake/speed-loss
+  - Happy path: With star active, wall hit produces no effects and star remains active
+  - Happy path: After shield consumed, next wall hit produces normal impact effects
+  - Edge case: Shield + star both active — star takes priority (shield not consumed)
+
+  **Verification:**
+  - Drive into a wall with shield: no impact effects, shield indicator disappears. Drive into wall with star: no effects, star persists.
+
+- [x] **Unit 4: Pickup VFX and audio**
+
+  **Goal:** Visual particle burst and audio chime when picking up an item box.
+
+  **Requirements:** R6
+
+  **Dependencies:** Unit 2
+
+  **Files:**
+  - Create: `js/ItemPickupVFX.js`
+  - Modify: `js/Audio.js` (add playItemPickup method)
+  - Modify: `js/main.js` (instantiate VFX, wire pickup callback)
+
+  **Approach:**
+  - **VFX:** Follow BoostBurst sprite pool pattern. Pool of 12 sprites with `AdditiveBlending`. On pickup, emit radial burst at box position. Color varies by powerup type: blue for speed, green for shield, gold for star.
+  - **Audio:** Add `playItemPickup()` to Audio.js following the `playBoostWhoosh()` oscillator pattern. Short ascending tone (~0.15s).
+  - Wire into ItemBoxManager: pass VFX and audio references, call on pickup.
+
+  **Patterns to follow:**
+  - BoostBurst.js for sprite pool VFX (pool size, emit pattern, update lifecycle).
+  - Audio.js playBoostWhoosh() for procedural Web Audio chime.
+
+  **Test scenarios:**
+  - Happy path: Picking up a box emits a visible particle burst at the box location
+  - Happy path: Picking up a box plays an audible chime
+  - Happy path: Particle burst color matches powerup type (blue/green/gold)
+  - Edge case: Rapid successive pickups don't crash (ring buffer wraps)
+
+  **Verification:**
+  - Pickup produces a satisfying burst of colored particles and a distinct chime sound.
+
+- [x] **Unit 5: HUD powerup indicator**
+
+  **Goal:** Show the active powerup type and remaining duration on the HUD during racing.
+
+  **Requirements:** R6, R8, R9
+
+  **Dependencies:** Unit 2
+
+  **Files:**
+  - Modify: `js/HUD.js` (add powerup indicator element)
+  - Modify: `js/RaceMode.js` (extend getDisplayState with powerup fields)
+
+  **Approach:**
+  - Extend `RaceMode.getDisplayState()` to include `shieldActive`, `starActive` from the local vehicle.
+  - In HUD constructor, create a small indicator element (positioned near the boost bar). Shows powerup icon/text + a shrinking timer bar.
+  - In `_updatePowerupIndicator(displayState)`, show/hide based on active state. Color-code: green for shield, gold for star. Speed boost is too brief (~2s) to need a HUD indicator.
+  - Hide during non-racing states.
+
+  **Patterns to follow:**
+  - HUD._updateBoostBar() pattern for state-driven DOM element updates.
+  - Boost bar color switching logic.
+
+  **Test scenarios:**
+  - Happy path: Shield pickup shows green indicator with "SHIELD" text
+  - Happy path: Star pickup shows gold indicator with "STAR" text
+  - Happy path: Indicator disappears when powerup timer expires
+  - Happy path: Speed Boost does not show a HUD indicator (too brief)
+  - Edge case: Picking up a new powerup while one is active replaces the indicator
+
+  **Verification:**
+  - Active shield/star shows a visible indicator near the boost bar that fades when the effect expires.
+
+- [x] **Unit 6: Multiplayer powerup sync**
+
+  **Goal:** Sync powerup visual effects to remote players so shield glow and star flash are visible.
+
+  **Requirements:** R10, R11
+
+  **Dependencies:** Units 2, 5
+
+  **Files:**
+  - Modify: `js/Vehicle.js` (extend getState/setTargetState with powerup fields)
+  - Modify: `js/PlayerManager.js` (read powerup state for remote vehicle visuals)
+  - Modify: `server.js` (relay new fields in world broadcast)
+
+  **Approach:**
+  - Add `shield` and `star` booleans to `Vehicle.getState()` return object.
+  - Add `shield` and `star` to `Vehicle.setTargetState()` parameters. In `updateRemote()`, set `shieldActive`/`starActive` from target state.
+  - In server.js world broadcast, include `shield` and `star` fields in the per-player object (same pattern as other state fields).
+  - In PlayerManager.update(), apply visual indicators (underglow color change, material tint) to remote vehicles based on their `shieldActive`/`starActive` state.
+  - Item box state is per-player (R10) — remote players picking up a box doesn't affect local box availability.
+
+  **Patterns to follow:**
+  - Existing `boost` field sync pattern in Vehicle.getState()/setTargetState().
+  - Remote boost state application in Vehicle.updateRemote() (line 433-441).
+
+  **Test scenarios:**
+  - Happy path: Remote player with shield active shows visual indicator on their vehicle
+  - Happy path: Remote player with star active shows distinct visual indicator
+  - Happy path: Local player picking up a box doesn't affect box availability for remote players
+  - Edge case: Player disconnects while powerup is active — no stale visual on reconnect
+
+  **Verification:**
+  - In multiplayer, other players' shield/star effects are visible on their vehicles.
+
+## System-Wide Impact
+
+- **Interaction graph:** ItemBoxManager is called from main.js game loop. Powerup state lives on Vehicle. ContactListener reads shield/star state. HUD reads display state. Network syncs powerup booleans.
+- **Error propagation:** If TrackIntel has no waypoints (broken track), ItemBoxManager should create zero boxes gracefully.
+- **State lifecycle risks:** Powerup timers must reset on race restart (Vehicle reset path in PlayerManager.setSpectating toggle).
+- **API surface parity:** Network state broadcast gains two new boolean fields — backward compatible (old clients ignore unknown fields).
+- **Unchanged invariants:** Drift stage machine, boost/nitro system, g-force camera, and existing particle systems are unchanged. Speed Boost reuses miniBoostTimer without modifying the drift-release grant path.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Item box Y position wrong on bump tiles | Use constant Y for v1; revisit with raycast placement if visually jarring |
+| Speed Boost overwrites drift-release mini-boost | Both write to same miniBoostTimer — use Math.max on timer to preserve the longer effect |
+| Network backward compatibility | New fields are additive booleans defaulting to false — old clients ignore them |
+| Performance with many boxes | N is typically 5-8 boxes per track; distance checks are O(players × boxes) which is trivial |
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-03-31-track-item-pickups-requirements.md](docs/brainstorms/2026-03-31-track-item-pickups-requirements.md)
+- Related code: `js/TrackIntel.js` (getDistributedPositions), `js/Vehicle.js` (miniBoostTimer, effectiveTopSpeed), `js/BoostBurst.js` (VFX pattern)
+- Related ideation: `docs/ideation/2026-03-31-open-v015-ideation.md` idea #5

--- a/docs/plans/2026-03-31-004-feat-visual-polish-pass-plan.md
+++ b/docs/plans/2026-03-31-004-feat-visual-polish-pass-plan.md
@@ -1,0 +1,208 @@
+---
+title: "feat: Visual polish pass — tire marks + spring-physics UI"
+type: feat
+status: completed
+date: 2026-03-31
+origin: docs/brainstorms/2026-03-31-visual-polish-pass-requirements.md
+---
+
+# feat: Visual polish pass — tire marks + spring-physics UI
+
+## Overview
+
+Two visual polish features: (1) persistent tire mark ribbons from rear wheels during drifts, and (2) damped spring animations on all HUD element transitions. Both address the gap between gameplay depth and visual feedback quality.
+
+## Problem Frame
+
+Drifting produces sparks but leaves no trace on the track. HUD elements appear/disappear instantly with no animation weight. (see origin: docs/brainstorms/2026-03-31-visual-polish-pass-requirements.md)
+
+## Requirements Trace
+
+- R1. Rear wheels leave visible marks during drifts and heavy braking
+- R2. Marks persist for the entire race
+- R3. Mark width scales with drift intensity
+- R4. Marks rendered as ribbon geometry
+- R5. Visible for all players in multiplayer
+- R6. Marks clear on race restart
+- R7. All HUD value changes animate with damped spring physics
+- R8. Affected: countdown, lap counter, boost bar, powerup indicator, race time, results
+- R9. Spring magnitude responds to change size
+- R10. Consistent spring parameters across all elements
+
+## Scope Boundaries
+
+- No marks during normal straight-line driving
+- No surface-type coloring (all marks dark gray)
+- No per-player mark colors
+- Spring UI is DOM CSS transforms, not WebGL
+- No spring on non-HUD elements
+
+## Key Technical Decisions
+
+- **Ribbon geometry via BufferGeometry with ring buffer (4000 segments per player):** Each segment is a quad between the current and previous wheel positions, width scaled by driftIntensity. Ring buffer prevents unbounded growth while handling any race length.
+- **Per-player TireMarks in PlayerManager:** Follow the DriftSparks pattern — one instance per player entry, updated in the per-player loop. Gives remote players marks too.
+- **Reusable SpringAnimator class:** A ~25 line damped harmonic oscillator utility. Each HUD element gets its own spring instance. Spring drives CSS `transform: scale()` and/or `translateY()`.
+- **Spring on value change, not every frame:** Springs activate when the target value changes, then settle. No per-frame cost when at rest.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Ring buffer size:** 4000 segments per player — handles a 3-lap race with continuous drifting at 60fps.
+- **Remote player marks:** Yes, via PlayerManager per-player pattern (same as DriftSparks).
+- **Spring utility location:** New `js/SpringAnimator.js` — reusable across HUD elements.
+
+### Deferred to Implementation
+
+- **Exact mark opacity/color values:** Tune visually during implementation.
+- **Spring stiffness/damping constants:** Start with k=150, d=12 (snappy with slight overshoot), tune by feel.
+
+## Implementation Units
+
+- [ ] **Unit 1: TireMarks ribbon geometry**
+
+  **Goal:** Create a ribbon mesh that extrudes along rear wheel ground contact paths during drifts.
+
+  **Requirements:** R1, R2, R3, R4, R6
+
+  **Dependencies:** None
+
+  **Files:**
+  - Create: `js/TireMarks.js`
+
+  **Approach:**
+  - Pre-allocate a BufferGeometry with 4000 * 6 vertices (2 triangles per segment quad). Use a write index that wraps.
+  - Each frame during drift (vehicle.driftStage > 0), sample both rear wheel world positions via `getWorldPosition()`. Emit a quad between previous and current positions.
+  - Quad width = base width (0.04) * clamp(driftIntensity, 0.5, 2.0) for R3.
+  - Material: `MeshBasicMaterial` with dark gray color (0x222222), opacity 0.6, transparent, depthWrite false.
+  - `clear()` method zeros the write index and hides all geometry — called on race restart for R6.
+  - `dispose()` removes mesh from scene and disposes geometry/material.
+
+  **Patterns to follow:**
+  - DriftSparks.js for per-player lifecycle and wheel world position sampling.
+  - Three.js BufferGeometry with dynamic draw range for ring-buffer rendering.
+
+  **Test scenarios:**
+  - Happy path: Drifting around a corner produces visible dark marks on the track surface
+  - Happy path: Mark width is wider during intense drifts than gentle drifts
+  - Happy path: Marks persist after the kart drives away
+  - Edge case: Ring buffer wraps — oldest marks disappear when buffer is full
+  - Happy path: clear() removes all visible marks
+
+  **Verification:**
+  - After drifting through a corner, dark tire marks are visible on the track behind the kart. After 3 laps, the racing line is visually drawn on the track.
+
+- [ ] **Unit 2: Wire TireMarks into PlayerManager**
+
+  **Goal:** Create per-player TireMarks instances and update them in the player loop. Clear on race restart.
+
+  **Requirements:** R5, R6
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Modify: `js/PlayerManager.js` (add TireMarks per player, update in loop, dispose on remove)
+  - Modify: `js/main.js` (clear marks on race restart if needed)
+
+  **Approach:**
+  - Add `tireMarks: new TireMarks(scene)` to each player entry alongside smokeTrails/driftSparks/boostFlame.
+  - In the per-player update loop, call `entry.tireMarks.update(dt, entry.vehicle)`.
+  - On `removeRemotePlayer`, call `entry.tireMarks.dispose()`.
+  - On race restart (setSpectating toggle), call `entry.tireMarks.clear()`.
+
+  **Patterns to follow:**
+  - DriftSparks integration pattern in PlayerManager (constructor, update loop, dispose, spectate toggle).
+
+  **Test scenarios:**
+  - Happy path: Local player leaves tire marks during drifts
+  - Happy path: Remote player's drifts also produce visible tire marks
+  - Happy path: Race restart clears all tire marks
+  - Edge case: Player disconnect disposes tire marks cleanly
+
+  **Verification:**
+  - In multiplayer, both local and remote player drifts leave visible tire marks. Restarting the race clears all marks.
+
+- [ ] **Unit 3: SpringAnimator utility**
+
+  **Goal:** Create a reusable damped spring animator for driving HUD element transitions.
+
+  **Requirements:** R7, R9, R10
+
+  **Dependencies:** None
+
+  **Files:**
+  - Create: `js/SpringAnimator.js`
+
+  **Approach:**
+  - Damped harmonic oscillator: `acceleration = -k * (position - target) - d * velocity`. Semi-implicit Euler integration.
+  - Constructor takes `stiffness` (default 150) and `damping` (default 12).
+  - `setTarget(value)` — sets the target rest position. The delta between old and new target determines bounce magnitude (R9).
+  - `update(dt)` — advances the spring. Returns current value. When velocity and displacement are below threshold (0.001), snaps to target (at rest).
+  - `isAtRest()` — returns true when settled.
+  - `reset(value)` — instantly sets position and target with zero velocity.
+
+  **Patterns to follow:**
+  - Simple utility class pattern like the existing `lerpAngle` function in Vehicle.js — pure math, no dependencies.
+
+  **Test scenarios:**
+  - Happy path: Setting a new target causes the value to overshoot then settle
+  - Happy path: Larger target delta produces larger overshoot (R9)
+  - Happy path: Spring eventually reaches rest (isAtRest returns true)
+  - Edge case: Very small target change settles quickly without visible bounce
+
+  **Verification:**
+  - SpringAnimator produces smooth overshoot-settle curves when target changes, and rests cleanly without jitter.
+
+- [ ] **Unit 4: Apply spring animations to HUD elements**
+
+  **Goal:** Replace instant value changes in HUD with spring-driven CSS animations.
+
+  **Requirements:** R7, R8, R10
+
+  **Dependencies:** Unit 3
+
+  **Files:**
+  - Modify: `js/HUD.js` (create SpringAnimator instances, apply to element transforms)
+
+  **Approach:**
+  - Create SpringAnimator instances for: countdown number (scale), lap counter (scale), boost bar fill (scaleX — not the width%, apply spring to a wrapper transform), powerup indicator (scale on appear/disappear), results text (translateY on slide-in).
+  - In `update()`, call each spring's `update(dt)` and apply the resulting value as a CSS transform.
+  - For countdown: on number change, set spring target to 1.0 from an initial 1.4 (scale punch in then settle).
+  - For lap counter: spring target 1.0 from 1.3 on lap change.
+  - For powerup indicator: spring target 1.0 from 0 on appear, spring to 0 on disappear.
+  - HUD needs `dt` passed into `update()` — extend the call signature if not already present.
+
+  **Patterns to follow:**
+  - Existing HUD `_updateBoostBar` pattern for state-driven DOM updates.
+  - Existing countdown `countPunch` CSS animation — replace with spring-driven scale.
+
+  **Test scenarios:**
+  - Happy path: Countdown numbers bounce in with overshoot when they change
+  - Happy path: Lap counter bounces when lap increments
+  - Happy path: Powerup indicator springs in on pickup and springs out on expiry
+  - Happy path: All spring animations use consistent stiffness/damping
+  - Edge case: Rapid successive changes (e.g., countdown 3→2→1→GO) each trigger their own spring
+
+  **Verification:**
+  - Every HUD element change has a visible, satisfying overshoot-settle animation. The feel is consistent and cohesive, not noisy.
+
+## System-Wide Impact
+
+- **Interaction graph:** TireMarks is per-player in PlayerManager, same lifecycle as DriftSparks. SpringAnimator is consumed only by HUD.js. No cross-system dependencies.
+- **State lifecycle:** Tire marks clear on race restart via PlayerManager.setSpectating. Spring states reset when HUD transitions between race states.
+- **Performance:** Tire mark ribbon geometry is one draw call per player with a bounded vertex count. Springs are pure math with no DOM cost when at rest.
+- **Unchanged invariants:** DriftSparks, BoostFlame, and all existing particle systems are unchanged. HUD layout and positioning remain the same — only transitions change.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Tire mark geometry z-fighting with track surface | Set renderOrder or slight Y offset (0.01) above track |
+| Spring animations feel too bouncy or distracting | Tunable k/d constants, start conservative (k=150, d=12) |
+| HUD.update() needs dt but may not receive it | Check call signature — extend if needed |
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-03-31-visual-polish-pass-requirements.md](docs/brainstorms/2026-03-31-visual-polish-pass-requirements.md)
+- Related code: `js/DriftSparks.js` (per-player VFX pattern), `js/HUD.js` (DOM update pattern), `js/PlayerManager.js` (per-player lifecycle)
+- Related ideation: `docs/ideation/2026-03-31-open-v015-round2-ideation.md` ideas #4, #9

--- a/js/Audio.js
+++ b/js/Audio.js
@@ -265,4 +265,70 @@ export class GameAudio {
 
 	}
 
+	playItemPickup() {
+
+		if ( ! this.listener ) return;
+
+		const ctx = this.listener.context;
+		if ( ! ctx || ctx.state === 'suspended' ) return;
+
+		try {
+
+			const osc = ctx.createOscillator();
+			const gain = ctx.createGain();
+
+			osc.type = 'sine';
+			osc.frequency.setValueAtTime( 600, ctx.currentTime );
+			osc.frequency.exponentialRampToValueAtTime( 1400, ctx.currentTime + 0.15 );
+
+			gain.gain.setValueAtTime( 0.25, ctx.currentTime );
+			gain.gain.exponentialRampToValueAtTime( 0.001, ctx.currentTime + 0.2 );
+
+			osc.connect( gain );
+			gain.connect( ctx.destination );
+
+			osc.start( ctx.currentTime );
+			osc.stop( ctx.currentTime + 0.2 );
+
+		} catch {
+
+			// Silently fail if audio context not ready
+
+		}
+
+	}
+
+	playShieldBreak() {
+
+		if ( ! this.listener ) return;
+
+		const ctx = this.listener.context;
+		if ( ! ctx || ctx.state === 'suspended' ) return;
+
+		try {
+
+			const osc = ctx.createOscillator();
+			const gain = ctx.createGain();
+
+			osc.type = 'triangle';
+			osc.frequency.setValueAtTime( 800, ctx.currentTime );
+			osc.frequency.exponentialRampToValueAtTime( 200, ctx.currentTime + 0.25 );
+
+			gain.gain.setValueAtTime( 0.3, ctx.currentTime );
+			gain.gain.exponentialRampToValueAtTime( 0.001, ctx.currentTime + 0.25 );
+
+			osc.connect( gain );
+			gain.connect( ctx.destination );
+
+			osc.start( ctx.currentTime );
+			osc.stop( ctx.currentTime + 0.25 );
+
+		} catch {
+
+			// Silently fail if audio context not ready
+
+		}
+
+	}
+
 }

--- a/js/Camera.js
+++ b/js/Camera.js
@@ -174,10 +174,10 @@ export class Camera {
 			// Camera roll depends on default XYZ Euler rotation order where Z = roll.
 			if ( this.gforceEnabled ) {
 
-				const inputX = vehicleState.inputX || 0;
-				const linearSpeed = vehicleState.linearSpeed || 0;
-				const bodyLeanRoll = vehicleState.bodyLeanRoll || 5;
-				const boostActive = vehicleState.boostActive || false;
+				const inputX = vehicleState.inputX ?? 0;
+				const linearSpeed = vehicleState.linearSpeed ?? 0;
+				const bodyLeanRoll = vehicleState.bodyLeanRoll ?? 5;
+				const boostActive = vehicleState.boostActive ?? false;
 
 				// Cornering lean signal: same formula as Vehicle.js updateBody()
 				const rawLean = -( inputX / bodyLeanRoll ) * linearSpeed;

--- a/js/DriftSparks.js
+++ b/js/DriftSparks.js
@@ -45,18 +45,31 @@ export class DriftSparks {
 		}
 
 		this.emitIndex = 0;
+		this._emitTimer = 0;
 
 	}
 
 	update( dt, vehicle ) {
 
-		// Only emit while actively drifting
+		// Only emit while actively drifting, rate-limited to ~30 particles/sec
 		if ( vehicle.driftStage > 0 ) {
 
-			const stage = Math.min( vehicle.driftStage, 3 );
+			this._emitTimer += dt;
+			const emitInterval = 1 / 15; // 15 emits/sec (2 wheels = 30 particles/sec)
 
-			if ( vehicle.wheelBL ) this._emitAtWheel( vehicle.wheelBL, vehicle, stage );
-			if ( vehicle.wheelBR ) this._emitAtWheel( vehicle.wheelBR, vehicle, stage );
+			if ( this._emitTimer >= emitInterval ) {
+
+				this._emitTimer -= emitInterval;
+				const stage = Math.min( vehicle.driftStage, 3 );
+
+				if ( vehicle.wheelBL ) this._emitAtWheel( vehicle.wheelBL, vehicle, stage );
+				if ( vehicle.wheelBR ) this._emitAtWheel( vehicle.wheelBR, vehicle, stage );
+
+			}
+
+		} else {
+
+			this._emitTimer = 0;
 
 		}
 

--- a/js/HUD.js
+++ b/js/HUD.js
@@ -1,3 +1,5 @@
+import { SpringAnimator } from './SpringAnimator.js';
+
 export class HUD {
 
 	constructor( onRestart, onReady ) {
@@ -16,6 +18,15 @@ export class HUD {
 
 		// Track last countdown value to detect changes and trigger the punch
 		this._lastCountdownText = '';
+
+		// Spring animators for HUD elements
+		this._countdownSpring = new SpringAnimator( 150, 12 );
+		this._countdownSpring.reset( 1 );
+		this._lapSpring = new SpringAnimator( 150, 12 );
+		this._lapSpring.reset( 1 );
+		this._powerupSpring = new SpringAnimator( 150, 12 );
+		this._powerupSpring.reset( 0 );
+		this._lastLap = - 1;
 
 		// ── Countdown overlay (centered, large text) ─────────────────────────
 		this._countdownEl = document.createElement( 'div' );
@@ -111,6 +122,17 @@ export class HUD {
 		this._boostContainer.appendChild( this._boostTrack );
 		document.body.appendChild( this._boostContainer );
 
+		// ── Powerup indicator ────────────────────────────────────────────────
+		this._powerupEl = document.createElement( 'div' );
+		this._powerupEl.style.cssText = [
+			'position:fixed', 'bottom:44px', 'left:50%', 'transform:translateX(-50%)',
+			'font:bold 12px sans-serif', 'padding:3px 12px',
+			'border-radius:4px', 'z-index:1000',
+			'pointer-events:none', 'user-select:none', 'display:none',
+			'text-align:center',
+		].join( ';' );
+		document.body.appendChild( this._powerupEl );
+
 		// ── Lobby panel (top-center: status + ready button) ──────────────────
 		this._lobbyPanel = document.createElement( 'div' );
 		this._lobbyPanel.style.cssText = [
@@ -142,7 +164,7 @@ export class HUD {
 
 	}
 
-	update( displayState, lobbyState ) {
+	update( dt, displayState, lobbyState ) {
 
 		this._currentState = displayState.state;
 
@@ -153,6 +175,7 @@ export class HUD {
 				this._raceHud.style.display = 'none';
 				this._resultsEl.style.display = 'none';
 				this._boostContainer.style.display = 'none';
+				this._powerupEl.style.display = 'none';
 				this._updateLobby( lobbyState );
 				break;
 
@@ -171,17 +194,19 @@ export class HUD {
 				const COUNT_COLORS = { '3': '#ff4444', '2': '#ffaa00', '1': '#44ff44', 'GO!': '#00ddff' };
 				this._countdownEl.style.color = COUNT_COLORS[ countText ] || '#ffffff';
 
-				// Scale punch on change — restart animation by clearing then reapplying
+				// Spring-driven scale punch on change
 				if ( countText !== this._lastCountdownText ) {
 
 					this._countdownEl.textContent = countText;
 					this._lastCountdownText = countText;
-					this._countdownEl.style.animation = 'none';
-					// Force reflow so the browser registers the reset before re-applying
-					void this._countdownEl.offsetWidth;
-					this._countdownEl.style.animation = 'countPunch 0.2s ease-out forwards';
+					this._countdownSpring.position = 1.5;
+					this._countdownSpring.velocity = 0;
+					this._countdownSpring.setTarget( 1.0 );
 
 				}
+
+				const countScale = this._countdownSpring.update( dt );
+				this._countdownEl.style.transform = `translate(-50%, -50%) scale(${ countScale })`;
 
 				break;
 			}
@@ -194,7 +219,22 @@ export class HUD {
 				this._boostContainer.style.display = 'block';
 				this._lapLine.textContent = `Lap ${ displayState.lap + 1 }/${ displayState.totalLaps }`;
 				this._timeLine.textContent = this._formatTime( displayState.elapsedTime );
+
+				// Spring bounce on lap change
+				if ( displayState.lap !== this._lastLap ) {
+
+					this._lapSpring.position = 1.3;
+					this._lapSpring.velocity = 0;
+					this._lapSpring.setTarget( 1.0 );
+					this._lastLap = displayState.lap;
+
+				}
+
+				const lapScale = this._lapSpring.update( dt );
+				this._lapLine.style.transform = `scale(${ lapScale })`;
+
 				this._updateBoostBar( displayState );
+				this._updatePowerupIndicator( dt, displayState );
 				break;
 
 			case 'finished':
@@ -202,6 +242,7 @@ export class HUD {
 				this._countdownEl.style.display = 'none';
 				this._raceHud.style.display = 'none';
 				this._boostContainer.style.display = 'none';
+				this._powerupEl.style.display = 'none';
 				this._resultsEl.style.display = 'block';
 				this._resultsTotalLine.textContent = `Total: ${ this._formatTime( displayState.totalTime ) }`;
 				this._resultsBestLine.textContent = `Best Lap: ${ this._formatTime( displayState.bestLap ) }`;
@@ -272,6 +313,52 @@ export class HUD {
 
 			this._boostFill.style.background = '#4fc3f7';
 			this._boostFill.style.animation = 'none';
+
+		}
+
+	}
+
+	_updatePowerupIndicator( dt, displayState ) {
+
+		const active = displayState.starActive || displayState.shieldActive;
+		const wasActive = this._powerupSpring.target > 0.5;
+
+		if ( active && ! wasActive ) {
+
+			this._powerupSpring.position = 0;
+			this._powerupSpring.velocity = 0;
+			this._powerupSpring.setTarget( 1.0 );
+
+		} else if ( ! active && wasActive ) {
+
+			this._powerupSpring.setTarget( 0 );
+
+		}
+
+		const pScale = this._powerupSpring.update( dt );
+
+		if ( pScale > 0.01 ) {
+
+			this._powerupEl.style.display = 'block';
+			this._powerupEl.style.transform = `scale(${ pScale })`;
+
+			if ( displayState.starActive ) {
+
+				this._powerupEl.textContent = 'STAR';
+				this._powerupEl.style.background = 'rgba(255,200,0,0.8)';
+				this._powerupEl.style.color = '#000';
+
+			} else {
+
+				this._powerupEl.textContent = 'SHIELD';
+				this._powerupEl.style.background = 'rgba(0,200,80,0.8)';
+				this._powerupEl.style.color = '#fff';
+
+			}
+
+		} else {
+
+			this._powerupEl.style.display = 'none';
 
 		}
 

--- a/js/ItemBoxManager.js
+++ b/js/ItemBoxManager.js
@@ -1,0 +1,161 @@
+import * as THREE from 'three';
+
+const PICKUP_RADIUS = 1.5;
+const COOLDOWN_TIME = 10;
+const BOX_Y = 1.0;
+
+// Powerup weights: speed 60%, shield 30%, star 10%
+const POWERUP_SPEED = 'speed';
+const POWERUP_SHIELD = 'shield';
+const POWERUP_STAR = 'star';
+
+function rollPowerup() {
+
+	const r = Math.random();
+	if ( r < 0.6 ) return POWERUP_SPEED;
+	if ( r < 0.9 ) return POWERUP_SHIELD;
+	return POWERUP_STAR;
+
+}
+
+const _boxGeo = new THREE.BoxGeometry( 0.6, 0.6, 0.6 );
+
+export class ItemBoxManager {
+
+	constructor( scene, trackIntel ) {
+
+		this.scene = scene;
+		this.boxes = [];
+
+		// Callback set by main.js for VFX/audio on pickup
+		this.onPickup = null;
+
+		const count = Math.max( 1, Math.floor( trackIntel.count / 3 ) );
+		const positions = trackIntel.getDistributedPositions( count );
+
+		const material = new THREE.MeshStandardMaterial( {
+			color: 0xffdd44,
+			emissive: 0xffaa00,
+			emissiveIntensity: 0.8,
+			metalness: 0.6,
+			roughness: 0.3,
+			transparent: true,
+			opacity: 1,
+		} );
+
+		for ( let i = 0; i < positions.length; i ++ ) {
+
+			const pos = positions[ i ];
+			const mesh = new THREE.Mesh( _boxGeo, material.clone() );
+			mesh.position.set( pos.x, BOX_Y, pos.z );
+			mesh.castShadow = false;
+			mesh.receiveShadow = false;
+			scene.add( mesh );
+
+			this.boxes.push( {
+				mesh,
+				x: pos.x,
+				z: pos.z,
+				available: true,
+				cooldownTimer: 0,
+			} );
+
+		}
+
+	}
+
+	update( dt, localVehicle ) {
+
+		for ( const box of this.boxes ) {
+
+			// Spin
+			box.mesh.rotation.y += dt * 2;
+			box.mesh.rotation.x += dt * 0.5;
+
+			// Respawn cooldown
+			if ( ! box.available ) {
+
+				box.cooldownTimer -= dt;
+
+				if ( box.cooldownTimer <= 0 ) {
+
+					box.available = true;
+					box.cooldownTimer = 0;
+					box.mesh.material.opacity = 1;
+					box.mesh.visible = true;
+
+				} else if ( box.cooldownTimer < 1 ) {
+
+					// Fade in during last 1 second of cooldown
+					box.mesh.visible = true;
+					box.mesh.material.opacity = 1 - box.cooldownTimer;
+
+				}
+
+				continue;
+
+			}
+
+			// Check pickup against local vehicle only (R10: per-player item state)
+			if ( ! localVehicle ) continue;
+
+			const dx = localVehicle.spherePos.x - box.x;
+			const dz = localVehicle.spherePos.z - box.z;
+
+			if ( dx * dx + dz * dz < PICKUP_RADIUS * PICKUP_RADIUS ) {
+
+				const powerup = rollPowerup();
+				this._applyPowerup( localVehicle, powerup );
+
+				// Start cooldown
+				box.available = false;
+				box.cooldownTimer = COOLDOWN_TIME;
+				box.mesh.visible = false;
+				box.mesh.material.opacity = 0;
+
+				if ( this.onPickup ) this.onPickup( box.x, box.z, powerup );
+
+			}
+
+		}
+
+	}
+
+	_applyPowerup( vehicle, type ) {
+
+		switch ( type ) {
+
+			case POWERUP_SPEED:
+				// Use Math.max to preserve a longer existing mini-boost
+				vehicle.miniBoostTimer = Math.max( vehicle.miniBoostTimer, 2.0 );
+				vehicle.miniBoostTopSpeed = Math.max( vehicle.miniBoostTopSpeed, 300 );
+				break;
+
+			case POWERUP_SHIELD:
+				vehicle.shieldActive = true;
+				vehicle.shieldTimer = 5.0;
+				break;
+
+			case POWERUP_STAR:
+				vehicle.starActive = true;
+				vehicle.starTimer = 3.0;
+				break;
+
+		}
+
+	}
+
+	dispose() {
+
+		for ( const box of this.boxes ) {
+
+			box.mesh.removeFromParent();
+			box.mesh.material.dispose();
+
+		}
+
+		this.boxes.length = 0;
+
+	}
+
+}

--- a/js/ItemPickupVFX.js
+++ b/js/ItemPickupVFX.js
@@ -1,0 +1,120 @@
+import * as THREE from 'three';
+
+const POOL_SIZE = 12;
+
+const POWERUP_COLORS = {
+	speed: [ 0x4488ff, 0x66aaff, 0x2266dd ],
+	shield: [ 0x44ff66, 0x22dd44, 0x88ffaa ],
+	star: [ 0xffdd44, 0xffaa00, 0xffee88 ],
+};
+
+export class ItemPickupVFX {
+
+	constructor( scene ) {
+
+		this.particles = [];
+
+		const map = new THREE.TextureLoader().load( 'sprites/smoke.png' );
+		this.material = new THREE.SpriteMaterial( {
+			map,
+			transparent: true,
+			depthWrite: false,
+			opacity: 0,
+			blending: THREE.AdditiveBlending,
+		} );
+
+		for ( let i = 0; i < POOL_SIZE; i ++ ) {
+
+			const sprite = new THREE.Sprite( this.material.clone() );
+			sprite.visible = false;
+			sprite.scale.setScalar( 0.2 );
+			scene.add( sprite );
+
+			this.particles.push( {
+				sprite,
+				life: 0,
+				maxLife: 0,
+				velocity: new THREE.Vector3(),
+				initialScale: 0,
+			} );
+
+		}
+
+		this.emitIndex = 0;
+
+	}
+
+	emit( x, z, powerupType ) {
+
+		const colors = POWERUP_COLORS[ powerupType ] || POWERUP_COLORS.speed;
+		const count = 10;
+
+		for ( let i = 0; i < count; i ++ ) {
+
+			const p = this.particles[ this.emitIndex ];
+			this.emitIndex = ( this.emitIndex + 1 ) % POOL_SIZE;
+
+			p.sprite.position.set( x, 1.0, z );
+			p.sprite.visible = true;
+			p.sprite.material.opacity = 1;
+			p.sprite.material.color.setHex( colors[ Math.floor( Math.random() * colors.length ) ] );
+
+			p.initialScale = 0.2 + Math.random() * 0.15;
+			p.sprite.scale.setScalar( p.initialScale );
+
+			// Radial burst outward + upward
+			const angle = Math.random() * Math.PI * 2;
+			const speed = 2 + Math.random() * 3;
+			p.velocity.set(
+				Math.cos( angle ) * speed,
+				2 + Math.random() * 2,
+				Math.sin( angle ) * speed
+			);
+
+			p.maxLife = 0.4;
+			p.life = p.maxLife;
+
+		}
+
+	}
+
+	update( dt ) {
+
+		for ( const p of this.particles ) {
+
+			if ( p.life <= 0 ) continue;
+
+			p.life -= dt;
+
+			if ( p.life <= 0 ) {
+
+				p.sprite.visible = false;
+				continue;
+
+			}
+
+			p.velocity.y -= 4 * dt;
+			p.sprite.position.addScaledVector( p.velocity, dt );
+
+			const t = 1 - ( p.life / p.maxLife );
+			p.sprite.scale.setScalar( p.initialScale * ( 1 - t * 0.5 ) );
+			p.sprite.material.opacity = 1 - t * t;
+
+		}
+
+	}
+
+	dispose() {
+
+		for ( const p of this.particles ) {
+
+			p.sprite.removeFromParent();
+			p.sprite.material.dispose();
+
+		}
+
+		this.material.dispose();
+
+	}
+
+}

--- a/js/PlayerManager.js
+++ b/js/PlayerManager.js
@@ -4,6 +4,7 @@ import { createVehicleBody, removeVehicleBody } from './Physics.js';
 import { SmokeTrails } from './Particles.js';
 import { DriftSparks } from './DriftSparks.js';
 import { BoostFlame } from './BoostFlame.js';
+import { TireMarks } from './TireMarks.js';
 
 const VEHICLE_MODEL_NAMES = [
 	'vehicle-truck-yellow',
@@ -41,6 +42,7 @@ export class PlayerManager {
 			smokeTrails: new SmokeTrails( this.scene ),
 			driftSparks: new DriftSparks( this.scene ),
 			boostFlame: new BoostFlame( this.scene ),
+			tireMarks: new TireMarks( this.scene ),
 			spectating: false,
 		} );
 
@@ -58,6 +60,7 @@ export class PlayerManager {
 			smokeTrails: new SmokeTrails( this.scene ),
 			driftSparks: new DriftSparks( this.scene ),
 			boostFlame: new BoostFlame( this.scene ),
+			tireMarks: new TireMarks( this.scene ),
 			spectating: false,
 		} );
 
@@ -101,6 +104,7 @@ export class PlayerManager {
 			smokeTrails: new SmokeTrails( this.scene ),
 			driftSparks: new DriftSparks( this.scene ),
 			boostFlame: new BoostFlame( this.scene ),
+			tireMarks: new TireMarks( this.scene ),
 			spectating: joinData.spectating || false,
 		} );
 
@@ -113,6 +117,7 @@ export class PlayerManager {
 
 		entry.driftSparks.dispose();
 		entry.boostFlame.dispose();
+		entry.tireMarks.dispose();
 
 		this.scene.remove( entry.vehicle.container );
 
@@ -149,7 +154,8 @@ export class PlayerManager {
 
 				entry.vehicle.setTargetState(
 					pState.pos, pState.rot, pState.vel, pState.angVel,
-					pState.speed, pState.drift, pState.boost
+					pState.speed, pState.drift, pState.boost,
+					pState.shield, pState.star
 				);
 
 			}
@@ -192,6 +198,11 @@ export class PlayerManager {
 			entry.vehicle.groundHeight = sy;
 			entry.vehicle.linearSpeed = 0;
 			entry.vehicle.angularSpeed = 0;
+			entry.vehicle.shieldActive = false;
+			entry.vehicle.shieldTimer = 0;
+			entry.vehicle.starActive = false;
+			entry.vehicle.starTimer = 0;
+			entry.tireMarks.clear();
 
 		}
 
@@ -218,6 +229,7 @@ export class PlayerManager {
 			entry.smokeTrails.update( dt, entry.vehicle );
 			entry.driftSparks.update( dt, entry.vehicle );
 			entry.boostFlame.update( dt, entry.vehicle );
+			entry.tireMarks.update( dt, entry.vehicle );
 
 		}
 

--- a/js/RaceMode.js
+++ b/js/RaceMode.js
@@ -173,6 +173,8 @@ export class RaceMode extends GameMode {
 		s.position = this._position;
 		s.boostMeter = v ? v.boostMeter : 0;
 		s.boostActive = v ? v.boostActive : false;
+		s.shieldActive = v ? v.shieldActive : false;
+		s.starActive = v ? v.starActive : false;
 
 		return s;
 

--- a/js/SpringAnimator.js
+++ b/js/SpringAnimator.js
@@ -1,0 +1,53 @@
+export class SpringAnimator {
+
+	constructor( stiffness = 150, damping = 12 ) {
+
+		this.k = stiffness;
+		this.d = damping;
+		this.position = 0;
+		this.velocity = 0;
+		this.target = 0;
+
+	}
+
+	setTarget( value ) {
+
+		this.target = value;
+
+	}
+
+	update( dt ) {
+
+		const displacement = this.position - this.target;
+		const acceleration = - this.k * displacement - this.d * this.velocity;
+
+		this.velocity += acceleration * dt;
+		this.position += this.velocity * dt;
+
+		// Snap to rest when settled
+		if ( Math.abs( displacement ) < 0.001 && Math.abs( this.velocity ) < 0.001 ) {
+
+			this.position = this.target;
+			this.velocity = 0;
+
+		}
+
+		return this.position;
+
+	}
+
+	isAtRest() {
+
+		return this.position === this.target && this.velocity === 0;
+
+	}
+
+	reset( value ) {
+
+		this.position = value;
+		this.target = value;
+		this.velocity = 0;
+
+	}
+
+}

--- a/js/TireMarks.js
+++ b/js/TireMarks.js
@@ -1,0 +1,153 @@
+import * as THREE from 'three';
+
+const MAX_SEGMENTS = 4000;
+const VERTS_PER_SEGMENT = 6; // 2 triangles
+const BASE_WIDTH = 0.04;
+
+const _posL = new THREE.Vector3();
+const _posR = new THREE.Vector3();
+const _right = new THREE.Vector3();
+
+export class TireMarks {
+
+	constructor( scene ) {
+
+		this._scene = scene;
+		this._writeIndex = 0;
+		this._segmentCount = 0;
+
+		// Previous wheel world positions (set on first sample)
+		this._prevBL = null;
+		this._prevBR = null;
+
+		const geometry = new THREE.BufferGeometry();
+		const positions = new Float32Array( MAX_SEGMENTS * VERTS_PER_SEGMENT * 3 );
+		geometry.setAttribute( 'position', new THREE.BufferAttribute( positions, 3 ) );
+		geometry.setDrawRange( 0, 0 );
+
+		const material = new THREE.MeshBasicMaterial( {
+			color: 0x222222,
+			transparent: true,
+			opacity: 0.5,
+			depthWrite: false,
+			side: THREE.DoubleSide,
+		} );
+
+		this._mesh = new THREE.Mesh( geometry, material );
+		this._mesh.renderOrder = 1; // Render above track surface
+		this._mesh.frustumCulled = false;
+		scene.add( this._mesh );
+
+		this._positions = positions;
+		this._geometry = geometry;
+
+	}
+
+	update( dt, vehicle ) {
+
+		// Only emit during drift
+		if ( vehicle.driftStage <= 0 || ! vehicle.wheelBL || ! vehicle.wheelBR ) {
+
+			this._prevBL = null;
+			this._prevBR = null;
+			return;
+
+		}
+
+		// Get current rear wheel world positions at ground level
+		vehicle.wheelBL.getWorldPosition( _posL );
+		vehicle.wheelBR.getWorldPosition( _posR );
+
+		const groundY = vehicle.container.position.y + 0.01;
+		_posL.y = groundY;
+		_posR.y = groundY;
+
+		if ( this._prevBL === null ) {
+
+			this._prevBL = _posL.clone();
+			this._prevBR = _posR.clone();
+			return;
+
+		}
+
+		// Width scales with drift intensity
+		const width = BASE_WIDTH * THREE.MathUtils.clamp( vehicle.driftIntensity, 0.5, 2.0 );
+
+		// Compute right vector from vehicle orientation for ribbon width
+		_right.set( 1, 0, 0 ).applyQuaternion( vehicle.container.quaternion );
+		_right.y = 0;
+		_right.normalize();
+
+		// Emit a segment for each rear wheel
+		this._emitSegment( this._prevBL, _posL, _right, width );
+		this._emitSegment( this._prevBR, _posR, _right, width );
+
+		this._prevBL.copy( _posL );
+		this._prevBR.copy( _posR );
+
+	}
+
+	_emitSegment( prev, curr, right, width ) {
+
+		const i = this._writeIndex * VERTS_PER_SEGMENT * 3;
+		this._writeIndex = ( this._writeIndex + 1 ) % MAX_SEGMENTS;
+
+		// Quad: prev-left, prev-right, curr-left, curr-right
+		const plx = prev.x - right.x * width;
+		const plz = prev.z - right.z * width;
+		const prx = prev.x + right.x * width;
+		const prz = prev.z + right.z * width;
+		const clx = curr.x - right.x * width;
+		const clz = curr.z - right.z * width;
+		const crx = curr.x + right.x * width;
+		const crz = curr.z + right.z * width;
+		const y = curr.y;
+
+		// Triangle 1: prev-left, curr-left, prev-right
+		this._positions[ i ] = plx;
+		this._positions[ i + 1 ] = y;
+		this._positions[ i + 2 ] = plz;
+		this._positions[ i + 3 ] = clx;
+		this._positions[ i + 4 ] = y;
+		this._positions[ i + 5 ] = clz;
+		this._positions[ i + 6 ] = prx;
+		this._positions[ i + 7 ] = y;
+		this._positions[ i + 8 ] = prz;
+
+		// Triangle 2: prev-right, curr-left, curr-right
+		this._positions[ i + 9 ] = prx;
+		this._positions[ i + 10 ] = y;
+		this._positions[ i + 11 ] = prz;
+		this._positions[ i + 12 ] = clx;
+		this._positions[ i + 13 ] = y;
+		this._positions[ i + 14 ] = clz;
+		this._positions[ i + 15 ] = crx;
+		this._positions[ i + 16 ] = y;
+		this._positions[ i + 17 ] = crz;
+
+		if ( this._segmentCount < MAX_SEGMENTS ) this._segmentCount ++;
+
+		this._geometry.attributes.position.needsUpdate = true;
+		this._geometry.setDrawRange( 0, this._segmentCount * VERTS_PER_SEGMENT );
+
+	}
+
+	clear() {
+
+		this._writeIndex = 0;
+		this._segmentCount = 0;
+		this._prevBL = null;
+		this._prevBR = null;
+		this._geometry.setDrawRange( 0, 0 );
+
+	}
+
+	dispose() {
+
+		this._mesh.removeFromParent();
+		this._geometry.dispose();
+		this._mesh.material.dispose();
+
+	}
+
+}

--- a/js/Vehicle.js
+++ b/js/Vehicle.js
@@ -143,6 +143,12 @@ export class Vehicle {
 		this.miniBoostTopSpeed = 0;
 		this.effectiveTopSpeed = 250;
 
+		// Powerup state
+		this.shieldActive = false;
+		this.shieldTimer = 0;
+		this.starActive = false;
+		this.starTimer = 0;
+
 	}
 
 	init( model ) {
@@ -274,9 +280,8 @@ export class Vehicle {
 			_forward.copy( localOff ).applyQuaternion( this.container.quaternion );
 
 			origin[ 0 ] = this.spherePos.x + _forward.x;
-			// Cast from a fixed height above the sphere — spherePos.y is set by physics
-			// and is always above ground, so this is stable regardless of groundHeight
-			origin[ 1 ] = this.spherePos.y + 2.0;
+			// Cast from above the current ground height — adapts to elevation changes
+			origin[ 1 ] = Math.max( this.spherePos.y, this.groundHeight ) + 3.0;
 			origin[ 2 ] = this.spherePos.z + _forward.z;
 
 			// Reset collector fully for reuse
@@ -356,7 +361,7 @@ export class Vehicle {
 
 	}
 
-	setTargetState( pos, rot, vel, angVel, speed, drift, boostActive ) {
+	setTargetState( pos, rot, vel, angVel, speed, drift, boostActive, shield, star ) {
 
 		this._targetPos = pos;
 		this._targetQuat.set( rot[ 0 ], rot[ 1 ], rot[ 2 ], rot[ 3 ] );
@@ -365,6 +370,8 @@ export class Vehicle {
 		this._targetSpeed = speed;
 		this._targetDrift = drift;
 		this._targetBoostActive = boostActive;
+		this._targetShieldActive = shield;
+		this._targetStarActive = star;
 
 	}
 
@@ -380,6 +387,8 @@ export class Vehicle {
 			speed: this.linearSpeed,
 			drift: this.driftIntensity,
 			boost: this.boostActive,
+			shield: this.shieldActive,
+			star: this.starActive,
 		};
 
 	}
@@ -440,8 +449,10 @@ export class Vehicle {
 		else if ( this.driftIntensity >= ( this.debug.driftStageThreshold || 0.5 ) ) this.driftStage = 1;
 		else this.driftStage = 0;
 
-		// Sync remote boost state
+		// Sync remote boost and powerup state
 		this.boostActive = this._targetBoostActive || false;
+		this.shieldActive = this._targetShieldActive || false;
+		this.starActive = this._targetStarActive || false;
 
 		this.updateBody( dt );
 		this.updateWheels( dt );
@@ -491,6 +502,7 @@ export class Vehicle {
 			if ( targetSpeed < 0 && this.linearSpeed > 0.01 ) {
 
 				this.linearSpeed = THREE.MathUtils.lerp( this.linearSpeed, 0.0, dt * this.debug.brakeRate );
+				if ( this.linearSpeed < 0.001 ) this.linearSpeed = 0;
 
 			} else if ( targetSpeed < 0 ) {
 
@@ -554,6 +566,10 @@ export class Vehicle {
 			this.linearSpeed = 0;
 			this.angularSpeed = 0;
 			this.acceleration = 0;
+			this.shieldActive = false;
+			this.shieldTimer = 0;
+			this.starActive = false;
+			this.starTimer = 0;
 			this.container.rotation.set( 0, 0, 0 );
 			this.container.quaternion.identity();
 
@@ -630,6 +646,33 @@ export class Vehicle {
 
 		}
 
+		// ── Powerup timers ───────────────────────────────────────────────────
+		if ( this.shieldTimer > 0 ) {
+
+			this.shieldTimer -= dt;
+
+			if ( this.shieldTimer <= 0 ) {
+
+				this.shieldActive = false;
+				this.shieldTimer = 0;
+
+			}
+
+		}
+
+		if ( this.starTimer > 0 ) {
+
+			this.starTimer -= dt;
+
+			if ( this.starTimer <= 0 ) {
+
+				this.starActive = false;
+				this.starTimer = 0;
+
+			}
+
+		}
+
 		// ── Boost / nitro ────────────────────────────────────────────────────
 		if ( this.boostActive ) {
 
@@ -676,7 +719,8 @@ export class Vehicle {
 		this.effectiveTopSpeed = Math.max(
 			this.debug.topSpeed,
 			this.boostActive ? this.debug.boostTopSpeed : 0,
-			this.miniBoostTimer > 0 ? this.miniBoostTopSpeed : 0
+			this.miniBoostTimer > 0 ? this.miniBoostTopSpeed : 0,
+			this.starActive ? this.debug.boostTopSpeed : 0
 		);
 
 		// ── Drive force — apply velocity toward desired speed ─────────────────
@@ -696,7 +740,7 @@ export class Vehicle {
 			const newVelX = this.sphereVel.x + ( _forward.x * desiredSpeed - this.sphereVel.x ) * blendRate;
 			const newVelZ = this.sphereVel.z + ( _forward.z * desiredSpeed - this.sphereVel.z ) * blendRate;
 
-			rigidBody.setLinearVelocity( this.physicsWorld, this.rigidBody, [ newVelX, 0, newVelZ ] );
+			rigidBody.setLinearVelocity( this.physicsWorld, this.rigidBody, [ newVelX, this.sphereVel.y, newVelZ ] );
 			rigidBody.setAngularVelocity( this.physicsWorld, this.rigidBody, [ 0, 0, 0 ] );
 
 		}

--- a/js/main.js
+++ b/js/main.js
@@ -18,6 +18,8 @@ import { TrackIntel } from './TrackIntel.js';
 import { WallSparks } from './WallSparks.js';
 import { BoostBurst } from './BoostBurst.js';
 import { Haptics } from './Haptics.js';
+import { ItemBoxManager } from './ItemBoxManager.js';
+import { ItemPickupVFX } from './ItemPickupVFX.js';
 
 
 const isMobile = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
@@ -393,6 +395,9 @@ async function init() {
 	raceMode.trackIntel = trackIntel;
 
 	const minimap = new Minimap( activeCells, bounds );
+
+	// ── Item boxes ───────────────────────────────────────────────────────────
+	const itemBoxManager = new ItemBoxManager( scene, trackIntel );
 
 	// ── Multiplayer race sync ────────────────────────────────────────────────
 
@@ -961,7 +966,16 @@ async function init() {
 	// ─── Juice particles (local player only) ─────────────────────────────────
 	const wallSparks = new WallSparks( scene );
 	const boostBurst = new BoostBurst( scene );
+	const itemPickupVFX = new ItemPickupVFX( scene );
 	const haptics = new Haptics();
+
+	// Wire item pickup feedback
+	itemBoxManager.onPickup = ( x, z, powerupType ) => {
+
+		itemPickupVFX.emit( x, z, powerupType );
+		audio.playItemPickup();
+
+	};
 
 	const contactListener = {
 		onContactAdded( bodyA, bodyB, manifold ) {
@@ -975,6 +989,19 @@ async function init() {
 
 			// Skip ground-like contacts (normal mostly vertical)
 			if ( Math.abs( wn[ 1 ] ) > 0.5 ) return;
+
+			// Star: ignore all wall impacts
+			if ( vehicle.starActive ) return;
+
+			// Shield: absorb one wall hit
+			if ( vehicle.shieldActive ) {
+
+				vehicle.shieldActive = false;
+				vehicle.shieldTimer = 0;
+				audio.playShieldBreak();
+				return;
+
+			}
 
 			// Velocity into the contact surface
 			const sv = vehicle.sphereVel;
@@ -992,7 +1019,7 @@ async function init() {
 			// Screen shake + wall sparks (directional)
 			const sign = ( bodyA === vehicle.rigidBody ) ? - 1 : 1;
 			cam.applyShake( wn[ 0 ] * sign, wn[ 2 ] * sign, speed );
-			wallSparks.emit( vehicle.spherePos, wn[ 0 ] * sign, wn[ 2 ] * sign, speed );
+			wallSparks.emit( vehicle.container.position, wn[ 0 ] * sign, wn[ 2 ] * sign, speed );
 			haptics.impulse( speed / 10 );
 
 		}
@@ -1036,6 +1063,9 @@ async function init() {
 
 		playerManager.update( dt, spectating ? { x: 0, z: 0, touchActive: false } : input );
 
+		// ─── Item box pickups ─────────────────────────────────────────────────
+		if ( ! spectating ) itemBoxManager.update( dt, vehicle );
+
 		// ─── Boost activation feedback ───────────────────────────────────────
 		if ( ! spectating && vehicle ) {
 
@@ -1049,7 +1079,7 @@ async function init() {
 				audio.playBoostWhoosh();
 
 				const fwd = new THREE.Vector3( 0, 0, 1 ).applyQuaternion( vehicle.container.quaternion );
-				boostBurst.emit( vehicle.spherePos, fwd.x, fwd.z );
+				boostBurst.emit( vehicle.container.position, fwd.x, fwd.z );
 
 			}
 
@@ -1078,6 +1108,7 @@ async function init() {
 		if ( ! spectating && vehicle ) haptics.setRumble( Math.abs( vehicle.linearSpeed ) );
 		wallSparks.update( dt );
 		boostBurst.update( dt );
+		itemPickupVFX.update( dt );
 
 		raceMode.update( dt, vehicle, playerManager.getActiveVehicles() );
 
@@ -1093,7 +1124,7 @@ async function init() {
 
 		}
 
-		hud.update( raceMode.getDisplayState(), raceLobby.getDisplayState() );
+		hud.update( dt, raceMode.getDisplayState(), raceLobby.getDisplayState() );
 		minimap.update( playerManager.getActiveVehicles(), raceMode.getDisplayState().state );
 
 		// Send local state to server (throttled internally at 20Hz)

--- a/server.js
+++ b/server.js
@@ -296,6 +296,9 @@ setInterval( () => {
 				angVel: p.lastState.angVel,
 				speed: p.lastState.speed,
 				drift: p.lastState.drift,
+				boost: p.lastState.boost,
+				shield: p.lastState.shield,
+				star: p.lastState.star,
 				spectating: p.spectating,
 			} );
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,19 @@
+# Kart Kids — Todo
+
+## Review Fixes (Applied 2026-03-31)
+
+- [x] P1: Preserve Y velocity in Vehicle.js drive force
+- [x] P1: Add brake speed cutoff to prevent infinite creep
+- [x] P1: Update CLAUDE.md to match GRID_SCALE = 1.0
+- [x] P2: Adaptive ray origin height for elevation changes
+- [x] P2: Wall sparks & boost burst emit at ground level
+- [x] P2: Rate-limit DriftSparks emission (~30/sec)
+- [x] P2: Use `??` instead of `||` for camera g-force defaults
+
+## Deferred Review Items
+
+- [ ] P1-3: Triangle mesh colliders built from visual meshes — if models gain LODs or decorative geometry, phantom collisions will appear. Consider separate collision meshes or filtering by mesh name convention.
+- [ ] P2-8: Single player can start race alone via RaceLobby (`zoneCount >= 1`). Decide if this is intentional or if solo should go through countdown differently.
+- [ ] P3-10: `window.isMobile` global — pass through constructor/config instead of polluting global scope.
+- [ ] P3-11: `Haptics.js` polls `navigator.getGamepads()` every frame — cache on `gamepadconnected` event instead.
+- [ ] P3-12: `Audio.js` boost whoosh bypasses Three.js spatial audio — connects directly to `ctx.destination`. Fine for local player, wrong if ever used for remote players.


### PR DESCRIPTION
## Summary
- **Item pickup system**: Speed boost (60%), shield (30%), star (10%) powerups auto-placed along track via TrackIntel. Instant trigger on drive-through with colored VFX burst, audio chime, and HUD indicator. Shield absorbs wall hits, star gives invincibility + max speed. Full multiplayer sync.
- **Tire marks**: Persistent ribbon geometry from rear wheels during drifts. Width scales with drift intensity. Visible for all players. Clears on race restart.
- **Spring-physics UI**: Damped harmonic oscillator drives countdown scale punch, lap counter bounce, and powerup indicator spring-in/out. Consistent feel across all HUD elements.
- **Review fixes**: Vehicle Y velocity preserved in drive force, brake speed cutoff, adaptive ray origin height, DriftSparks rate limiting, Camera `??` defaults, CLAUDE.md grid scale update, distinct shield-break sound.

## New Files
- `js/ItemBoxManager.js` — Box placement, rendering, respawn, pickup detection, powerup application
- `js/ItemPickupVFX.js` — Color-coded sprite pool burst on pickup
- `js/SpringAnimator.js` — Reusable damped spring utility
- `js/TireMarks.js` — Ribbon geometry tire mark system

## Test Plan
- [ ] Drive through item boxes — hear chime, see colored particle burst
- [ ] Speed boost (most common) — brief speed increase
- [ ] Shield (green HUD label) — drive into wall, no impact effects
- [ ] Star (gold HUD label) — max speed, walls have no effect for 3s
- [ ] Boxes respawn after ~10 seconds with fade-in
- [ ] Drift around corners — dark tire marks visible on track
- [ ] Tire marks persist across laps, clear on race restart
- [ ] Countdown numbers bounce in with spring animation
- [ ] Lap counter bounces when lap changes
- [ ] Powerup indicator springs in on pickup, springs out on expiry

🤖 Generated with [Claude Code](https://claude.com/claude-code)