### PR TITLE
fix: add error boundary around game loop to prevent silent crashes

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -867,6 +867,7 @@ async function init() {
 
 	let lastFrameTime = 0;
 	let shadowFrameCounter = 0;
+	let _loopErrorCount = 0;
 
 	function animate() {
 
@@ -881,6 +882,30 @@ async function init() {
 
 		}
 
+		try {
+
+		_animateInner();
+
+		} catch ( err ) {
+
+			_loopErrorCount ++;
+			console.error( '[game-loop] Uncaught error in frame (count: ' + _loopErrorCount + '):', err );
+
+			// Stop the loop after 10 consecutive errors to avoid log spam
+			if ( _loopErrorCount >= 10 ) {
+
+				console.error( '[game-loop] Too many errors — halting game loop' );
+				return;
+
+			}
+
+		}
+
+	}
+
+	function _animateInner() {
+
+		_loopErrorCount = 0;
 		fpsFrames ++;
 		const now = performance.now();
 		if ( now - fpsTime >= 500 ) {


### PR DESCRIPTION
## Summary
- Wraps the game loop body in a try-catch error boundary
- Logs errors with a consecutive error counter
- After 10 consecutive errors, halts the loop to prevent log spam
- A single successful frame resets the counter, enabling self-recovery from transient errors
- Previously, any unhandled error in the 30+ subsystem updates silently killed the game loop

## Test plan
- [ ] Load game and play normally — verify no change in behavior
- [ ] Introduce a temporary error (e.g., reference an undefined variable in a subsystem update) — verify error is logged and game continues
- [ ] Verify the game loop halts after 10 consecutive errors (check console)

🤖 Generated with [Claude Code](https://claude.com/claude-code)