### PR TITLE
refactor: reuse followVehicle in postFX update

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1190,8 +1190,7 @@ async function init() {
 		// Update dynamic post-processing effects
 		if ( postFX ) {
 
-			const followV = spectating ? cam.spectatorTarget : vehicle;
-			postFX.update( dt, cam.getVelocity(), followV ? followV.boostActive : false );
+			postFX.update( dt, cam.getVelocity(), followVehicle ? followVehicle.boostActive : false );
 
 		}
 


### PR DESCRIPTION
## Summary
- Removes redundant `followV` ternary in the postFX update block by reusing the `followVehicle` variable already computed ~80 lines earlier in the same game loop scope
- Both compute `spectating ? cam.spectatorTarget : vehicle` — now done once

## Test plan
- [ ] Play a race — verify post-processing effects (motion blur, boost blur) work normally
- [ ] Enter spectator mode — verify post-processing tracks the spectated vehicle

🤖 Generated with [Claude Code](https://claude.com/claude-code)