### PR TITLE
chore: remove 4 unused imports from UI and track editor

### DIFF
--- a/js/track-editor/commands/CycleElevationCommand.js
+++ b/js/track-editor/commands/CycleElevationCommand.js
@@ -2,8 +2,6 @@
 // Cycles elevation on a straight tile. Uses full grid snapshot because
 // elevation changes affect the entire elevated run + ramps.
 
-import { Command } from '../core/Command.js';
-
 export class CycleElevationCommand {
 
 	/**

--- a/js/track-editor/commands/ReplaceTileCommand.js
+++ b/js/track-editor/commands/ReplaceTileCommand.js
@@ -1,8 +1,6 @@
 // ─── ReplaceTileCommand ──────────────────────────────────────────────────────
 // Replaces a tile's type in-place, preserving elevation, orient, and flags.
 
-import { Command } from '../core/Command.js';
-
 export class ReplaceTileCommand {
 
 	constructor( project, gx, gz, newType, meshFactory, eventBus ) {

--- a/js/ui/pages/page21-settings/Page21SettingsController.js
+++ b/js/ui/pages/page21-settings/Page21SettingsController.js
@@ -33,7 +33,6 @@ import { Page21SettingsView }    from './Page21SettingsView.js';
 import { RouteIds }              from '../../enums/RouteIds.js';
 import { PageIds }               from '../../enums/PageIds.js';
 import { EventIds }              from '../../enums/EventIds.js';
-import * as Nav                  from '../../core/NavigationService.js';
 
 /** Map URL hash fragments to Tabs activeId values. */
 const HASH_TO_TAB = Object.freeze( {

--- a/js/ui/pages/page23-tutorial/Page23TutorialController.js
+++ b/js/ui/pages/page23-tutorial/Page23TutorialController.js
@@ -31,7 +31,6 @@ import { Page23TutorialView }    from './Page23TutorialView.js';
 import { RouteIds }              from '../../enums/RouteIds.js';
 import { PageIds }               from '../../enums/PageIds.js';
 import { EventIds }              from '../../enums/EventIds.js';
-import * as Nav                  from '../../core/NavigationService.js';
 
 /** localStorage key for tutorial completion flag. */
 const TUTORIAL_COMPLETE_KEY = 'kk:tutorial:complete';


### PR DESCRIPTION
## Summary
- Removes unused `Nav` (NavigationService) import from `Page21SettingsController.js` and `Page23TutorialController.js` — both use inherited navigation methods from `PageControllerBase`
- Removes unused `Command` import from `ReplaceTileCommand.js` and `CycleElevationCommand.js` — both implement execute/undo directly without extending `Command`

## Test plan
- [ ] Verify settings page loads and navigates correctly
- [ ] Verify tutorial page loads and navigates correctly
- [ ] Verify tile replacement works in track editor
- [ ] Verify elevation cycling works in track editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)