### PR TITLE
refactor: centralize VEHICLE_BASE constant between ModelLoader and AIManager

### DIFF
--- a/js/AIManager.js
+++ b/js/AIManager.js
@@ -10,8 +10,7 @@ import { AIController } from './AIController.js';
 import { AI_PROFILES } from './AIProfiles.js';
 import { ItemSlotManager } from './ItemSlotManager.js';
 import { rigidBody } from 'crashcat';
-
-const VEHICLE_BASE_MODEL = 'vehicle-truck-yellow';
+import { VEHICLE_BASE } from './ModelLoader.js';
 
 // Golden-angle hue distribution — ensures no two adjacent AIs share similar colors
 function generateAIColors( count ) {
@@ -97,7 +96,7 @@ export class AIManager {
 
 	_spawnAI( index ) {
 
-		const model = this.models[ VEHICLE_BASE_MODEL ];
+		const model = this.models[ VEHICLE_BASE ];
 
 		const charName = CHARACTER_MODEL_NAMES[ index % CHARACTER_MODEL_NAMES.length ];
 		const characterModel = this.models[ charName ] || null;

--- a/js/ModelLoader.js
+++ b/js/ModelLoader.js
@@ -6,7 +6,7 @@ import { applyTrackAsphaltMode } from './TrackAsphaltMode.js';
 THREE.Cache.enabled = true;
 
 // Vehicle color tints — load only the yellow base, derive others via clone+tint
-const VEHICLE_BASE = 'vehicle-truck-yellow';
+export const VEHICLE_BASE = 'vehicle-truck-yellow';
 const VEHICLE_TINTS = {
 	'vehicle-truck-yellow': null, // base model, no tint
 	'vehicle-truck-green': new THREE.Color( 0.45, 1.0, 0.45 ),


### PR DESCRIPTION
## Summary
- Exports `VEHICLE_BASE` from `ModelLoader.js` as the single source of truth for the base vehicle model name
- Replaces the duplicate `VEHICLE_BASE_MODEL` constant in `AIManager.js` with the import
- Prevents divergence if the base vehicle model name changes

## Test plan
- [ ] Verify AI vehicles spawn correctly with the yellow base model
- [ ] Verify AI vehicle color tinting works (green, purple, red variants)
- [ ] Verify player vehicles load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)