### PR TITLE
perf: hoist ContactHandler per-collision object literal

### DIFF
--- a/js/ContactHandler.js
+++ b/js/ContactHandler.js
@@ -7,6 +7,7 @@ const _bumpRight = new THREE.Vector3();
 const _bumpNormalXZ = new THREE.Vector3();
 const _bumpLateral = new THREE.Vector3();
 const _bumpPushDir = new THREE.Vector3();
+const _collisionPoint = { x: 0, y: 0, z: 0 };
 
 
 /**
@@ -128,10 +129,10 @@ export function createContactListener( ctx ) {
 
 			const posA = vehicleA.container.position;
 			const posB = vehicleB.container.position;
-			wallSparks.emit(
-				{ x: ( posA.x + posB.x ) / 2, y: posA.y, z: ( posA.z + posB.z ) / 2 },
-				_bumpPushDir.x, _bumpPushDir.z, pushMag
-			);
+			_collisionPoint.x = ( posA.x + posB.x ) / 2;
+			_collisionPoint.y = posA.y;
+			_collisionPoint.z = ( posA.z + posB.z ) / 2;
+			wallSparks.emit( _collisionPoint, _bumpPushDir.x, _bumpPushDir.z, pushMag );
 			haptics.impulse( severity * 0.6 );
 
 		}


### PR DESCRIPTION
Replaces the per-collision `{ x, y, z }` object literal in `_applyBump` with a reusable module-level `_collisionPoint` object, matching the existing pattern for the five `THREE.Vector3` scratch vectors. Eliminates a short-lived allocation on every vehicle bump event.

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)