### PR TITLE
feat: wrong-way detection with pulsing HUD warning

### DIFF
--- a/js/HUD.js
+++ b/js/HUD.js
@@ -54,6 +54,18 @@ export class HUD {
 		this._raceHud.appendChild( this._timeLine );
 		document.body.appendChild( this._raceHud );
 
+		// ── Wrong-way warning (centered, large pulsing text) ────────────────
+		this._wrongWayEl = document.createElement( 'div' );
+		this._wrongWayEl.textContent = 'WRONG WAY';
+		this._wrongWayEl.style.cssText = [
+			'position:fixed', 'top:35%', 'left:50%', 'transform:translate(-50%,-50%)',
+			'font:bold 56px/1 monospace', 'color:#ff3333',
+			'text-shadow:0 0 30px rgba(255,0,0,0.7), 0 0 60px rgba(255,0,0,0.4)',
+			'z-index:1001', 'pointer-events:none', 'user-select:none', 'display:none',
+			'animation:boostPulse 0.5s ease-in-out infinite alternate',
+		].join( ';' );
+		document.body.appendChild( this._wrongWayEl );
+
 		// ── Results overlay (centered panel) ─────────────────────────────────
 		this._resultsEl = document.createElement( 'div' );
 		this._resultsEl.style.cssText = [
@@ -187,6 +199,7 @@ export class HUD {
 				this._resultsEl.style.display = 'none';
 				this._boostContainer.style.display = 'none';
 				this._powerupEl.style.display = 'none';
+				this._wrongWayEl.style.display = 'none';
 				this._updateLobby( lobbyState );
 				break;
 
@@ -196,6 +209,7 @@ export class HUD {
 				this._raceHud.style.display = 'none';
 				this._boostContainer.style.display = 'none';
 				this._countdownEl.style.display = 'block';
+				this._wrongWayEl.style.display = 'none';
 
 				const countText = displayState.countdown > 0
 					? displayState.countdown.toString()
@@ -247,6 +261,7 @@ export class HUD {
 				this._updateBoostBar( displayState );
 				this._updateDriftIndicator( displayState );
 				this._updatePowerupIndicator( dt, displayState );
+				this._wrongWayEl.style.display = displayState.wrongWay ? 'block' : 'none';
 				break;
 
 			case 'finished':
@@ -255,6 +270,7 @@ export class HUD {
 				this._raceHud.style.display = 'none';
 				this._boostContainer.style.display = 'none';
 				this._powerupEl.style.display = 'none';
+				this._wrongWayEl.style.display = 'none';
 				this._resultsEl.style.display = 'block';
 				this._resultsTotalLine.textContent = `Total: ${ this._formatTime( displayState.totalTime ) }`;
 				this._resultsBestLine.textContent = `Best Lap: ${ this._formatTime( displayState.bestLap ) }`;

--- a/js/RaceMode.js
+++ b/js/RaceMode.js
@@ -38,6 +38,11 @@ export class RaceMode extends GameMode {
 		this._position = 1;
 		this._aiVehicleSet = new Set();
 
+		// Wrong-way detection
+		this._prevProgress = 0;
+		this._wrongWayTimer = 0;
+		this._wrongWay = false;
+
 		this._state = STATE_IDLE;
 		this._countdownTime = 0;
 		this._networkCountdownElapsed = 0;
@@ -126,6 +131,7 @@ export class RaceMode extends GameMode {
 			this._elapsedTime += dt;
 			this._checkFinishLine( vehicle );
 			this._updatePosition( vehicle, activeVehicles, aiRaceData );
+			this._updateWrongWay( dt, vehicle );
 
 		}
 
@@ -204,6 +210,7 @@ export class RaceMode extends GameMode {
 		s.starActive = v ? v.starActive : false;
 		s.driftActive = v ? v.driftActive : false;
 		s.driftSparkTier = v ? v.driftSparkTier : 0;
+		s.wrongWay = this._wrongWay;
 
 		return s;
 
@@ -243,6 +250,9 @@ export class RaceMode extends GameMode {
 		this._prevPos = null;
 		this._lastSegmentHint = null;
 		this._position = 1;
+		this._prevProgress = 0;
+		this._wrongWayTimer = 0;
+		this._wrongWay = false;
 
 		if ( this._finishLine ) this._finishLine.resetCooldown();
 
@@ -315,6 +325,35 @@ export class RaceMode extends GameMode {
 		}
 
 		this._position = ahead + 1;
+
+	}
+
+	_updateWrongWay( dt, vehicle ) {
+
+		if ( ! this.trackIntel || ! vehicle ) return;
+
+		const pos = vehicle.vehPos;
+		const progress = this.trackIntel.getProgress( pos.x, pos.z, this._lastSegmentHint );
+
+		// Detect sustained backward movement (progress decreasing).
+		// Allow small fluctuations (threshold 0.005) to avoid false positives from lateral movement.
+		// Ignore progress wrapping near lap boundary (progress near 0 or 1).
+		const delta = progress - this._prevProgress;
+		const wrapping = this._prevProgress > 0.9 && progress < 0.1;
+		const reverseWrap = this._prevProgress < 0.1 && progress > 0.9;
+
+		if ( ! wrapping && ( delta < - 0.005 || reverseWrap ) ) {
+
+			this._wrongWayTimer += dt;
+
+		} else {
+
+			this._wrongWayTimer = Math.max( 0, this._wrongWayTimer - dt * 2 );
+
+		}
+
+		this._wrongWay = this._wrongWayTimer > 1.5;
+		this._prevProgress = progress;
 
 	}
 


### PR DESCRIPTION
Detects when the player drives backward on the track for 1.5+ seconds and shows a red pulsing "WRONG WAY" warning. Uses TrackIntel waypoint progress tracking already computed each frame by RaceMode. Handles lap boundary wrapping (progress 0.9→0.1 is forward, 0.1→0.9 is backward). Warning decays at 2x speed when the player turns around, dismissing quickly.

- **RaceMode.js**: `_updateWrongWay()` compares per-frame progress delta with 0.005 dead zone, accumulates timer, exposes via `getDisplayState().wrongWay`
- **HUD.js**: Red 56px pulsing text overlay at 35% screen height, hidden in all non-racing states

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)