### PR TITLE
feat: race position change audio callouts

### DIFF
--- a/js/Audio.js
+++ b/js/Audio.js
@@ -373,6 +373,72 @@ export class GameAudio {
 
 	}
 
+	playPositionGain() {
+
+		if ( ! this.listener ) return;
+
+		const ctx = this.listener.context;
+		if ( ! ctx || ctx.state === 'suspended' ) return;
+
+		try {
+
+			const osc = ctx.createOscillator();
+			const gain = ctx.createGain();
+
+			osc.type = 'sine';
+			osc.frequency.setValueAtTime( 600, ctx.currentTime );
+			osc.frequency.linearRampToValueAtTime( 900, ctx.currentTime + 0.12 );
+
+			gain.gain.setValueAtTime( 0.2, ctx.currentTime );
+			gain.gain.exponentialRampToValueAtTime( 0.001, ctx.currentTime + 0.15 );
+
+			osc.connect( gain );
+			gain.connect( this._sfxGain );
+
+			osc.start( ctx.currentTime );
+			osc.stop( ctx.currentTime + 0.15 );
+
+		} catch {
+
+			// Silently fail if audio context not ready
+
+		}
+
+	}
+
+	playPositionLoss() {
+
+		if ( ! this.listener ) return;
+
+		const ctx = this.listener.context;
+		if ( ! ctx || ctx.state === 'suspended' ) return;
+
+		try {
+
+			const osc = ctx.createOscillator();
+			const gain = ctx.createGain();
+
+			osc.type = 'sine';
+			osc.frequency.setValueAtTime( 500, ctx.currentTime );
+			osc.frequency.linearRampToValueAtTime( 350, ctx.currentTime + 0.12 );
+
+			gain.gain.setValueAtTime( 0.15, ctx.currentTime );
+			gain.gain.exponentialRampToValueAtTime( 0.001, ctx.currentTime + 0.15 );
+
+			osc.connect( gain );
+			gain.connect( this._sfxGain );
+
+			osc.start( ctx.currentTime );
+			osc.stop( ctx.currentTime + 0.15 );
+
+		} catch {
+
+			// Silently fail if audio context not ready
+
+		}
+
+	}
+
 	playItemPickup() {
 
 		if ( ! this.listener ) return;

--- a/js/main.js
+++ b/js/main.js
@@ -867,6 +867,7 @@ async function init() {
 
 	let lastFrameTime = 0;
 	let shadowFrameCounter = 0;
+	let _prevRacePosition = 0;
 
 	function animate() {
 
@@ -1082,10 +1083,22 @@ async function init() {
 
 		}
 
-		hud.update( dt, raceMode.getDisplayState(), raceLobby.getDisplayState() );
+		const _ds = raceMode.getDisplayState();
+		hud.update( dt, _ds, raceLobby.getDisplayState() );
+
+		// Position-change audio callouts
+		if ( _ds.state === 'racing' && _ds.position !== _prevRacePosition && _prevRacePosition > 0 ) {
+
+			if ( _ds.position < _prevRacePosition ) audio.playPositionGain();
+			else audio.playPositionLoss();
+
+		}
+
+		_prevRacePosition = _ds.state === 'racing' ? _ds.position : 0;
+
 		if ( ! spectating && vehicle ) hudDamage.update( vehicle.health, vehicle.itemSlot ? vehicle.itemSlot.heldItemId : null, dt );
 		speedometer.update( dt, vehicle.linearSpeed, vehicle.momentum, vehicle.boostActive, vehicle.effectiveTopSpeed, vehicle.debug.topSpeed );
-		minimap.update( allActiveVehicles, raceMode.getDisplayState().state );
+		minimap.update( allActiveVehicles, _ds.state );
 
 		// Send local state to server (throttled internally at 20Hz)
 		if ( multiplayer && network.connected && ! spectating ) {


### PR DESCRIPTION
Adds short synthesized audio cues when the player's race position changes: an ascending sine sweep (600-900 Hz) for gaining a position, and a descending sweep (500-350 Hz) for losing one. Both are 150ms with quick fade-out, routed through the existing SFX gain node.

Position tracking resets when not in racing state to avoid false triggers on race start. Also consolidates a duplicate `getDisplayState()` call — minimap now reuses the cached display state object.

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)