### PR TITLE
feat: remix button for varied race restarts

### DIFF
--- a/js/AIController.js
+++ b/js/AIController.js
@@ -35,6 +35,12 @@ export class AIController {
 
 	}
 
+	setProfile( profile ) {
+
+		this._profile = Object.assign( {}, DEFAULT_PROFILE, profile );
+
+	}
+
 	update( dt, vehicle ) {
 
 		const trackIntel = this._trackIntel;

--- a/js/AIManager.js
+++ b/js/AIManager.js
@@ -399,6 +399,29 @@ export class AIManager {
 
 	}
 
+	shuffleProfiles() {
+
+		// Fisher-Yates shuffle of profile assignments
+		const profiles = AI_PROFILES.slice();
+		for ( let i = profiles.length - 1; i > 0; i -- ) {
+
+			const j = Math.floor( Math.random() * ( i + 1 ) );
+			[ profiles[ i ], profiles[ j ] ] = [ profiles[ j ], profiles[ i ] ];
+
+		}
+
+		for ( let i = 0; i < this._racers.length; i ++ ) {
+
+			const ai = this._racers[ i ];
+			const profile = profiles[ i % profiles.length ];
+			ai.profile = profile;
+			ai.controller.setProfile( profile );
+			ai.vehicle.weight = profile.weight || 5;
+
+		}
+
+	}
+
 	// ── Queries ──────────────────────────────────────────────────────────────
 
 	getActiveVehicles() {

--- a/js/HUD.js
+++ b/js/HUD.js
@@ -2,10 +2,11 @@ import { SpringAnimator } from './SpringAnimator.js';
 
 export class HUD {
 
-	constructor( onRestart, onReady ) {
+	constructor( onRestart, onReady, onRemix ) {
 
 		this._onRestart = onRestart;
 		this._onReady = onReady;
+		this._onRemix = onRemix;
 		this._currentState = 'idle';
 
 		// ── Inject CSS keyframes for animations ──────────────────────────────
@@ -73,7 +74,7 @@ export class HUD {
 		this._restartBtn = document.createElement( 'button' );
 		this._restartBtn.textContent = 'RESTART';
 		this._restartBtn.style.cssText = [
-			'font:bold 20px monospace', 'margin-top:20px', 'padding:10px 32px',
+			'font:bold 20px monospace', 'padding:10px 32px',
 			'background:#fff', 'color:#000', 'border:none', 'border-radius:6px',
 			'cursor:pointer',
 		].join( ';' );
@@ -83,10 +84,28 @@ export class HUD {
 
 		} );
 
+		this._remixBtn = document.createElement( 'button' );
+		this._remixBtn.textContent = 'REMIX';
+		this._remixBtn.style.cssText = [
+			'font:bold 20px monospace', 'margin-top:10px', 'margin-left:12px', 'padding:10px 32px',
+			'background:#6366f1', 'color:#fff', 'border:none', 'border-radius:6px',
+			'cursor:pointer',
+		].join( ';' );
+		this._remixBtn.addEventListener( 'click', () => {
+
+			if ( this._onRemix ) this._onRemix();
+
+		} );
+
+		const btnRow = document.createElement( 'div' );
+		btnRow.style.cssText = 'margin-top:20px; display:flex; justify-content:center; gap:12px';
+		btnRow.appendChild( this._restartBtn );
+		btnRow.appendChild( this._remixBtn );
+
 		this._resultsEl.appendChild( this._resultsTitle );
 		this._resultsEl.appendChild( this._resultsTotalLine );
 		this._resultsEl.appendChild( this._resultsBestLine );
-		this._resultsEl.appendChild( this._restartBtn );
+		this._resultsEl.appendChild( btnRow );
 		document.body.appendChild( this._resultsEl );
 
 		// ── Boost meter bar ──────────────────────────────────────────────────

--- a/js/main.js
+++ b/js/main.js
@@ -442,7 +442,8 @@ async function init() {
 
 	const hud = new HUD(
 		() => { raceMode.reset(); aiManager.resetRace(); raceLobby.reset(); },
-		() => raceLobby.setReady( playerManager.localId )
+		() => raceLobby.setReady( playerManager.localId ),
+		() => { aiManager.shuffleProfiles(); raceMode.reset(); aiManager.resetRace(); aiManager.teleportToGrid( vehicle ); raceLobby.reset(); }
 	);
 
 	const intelCells = customCells ? deriveRampCells( activeCells ) : activeCells;


### PR DESCRIPTION
Adds a "REMIX" button alongside "RESTART" on the race results screen. Remix re-races the same track with shuffled AI personality profiles and randomized starting grid positions, making each replay feel different without requiring new content.

- **AIController.js**: `setProfile()` method for runtime personality hot-swap
- **AIManager.js**: `shuffleProfiles()` using Fisher-Yates shuffle across existing AI_PROFILES (Aggressive, Cautious, Drifter, Default)
- **HUD.js**: Purple REMIX button in a flex row with RESTART, accepts `onRemix` callback
- **main.js**: Wires remix to shuffle profiles, re-teleport grid, and reset race state

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)