### PR TITLE
feat: adaptive AI difficulty from finish position history

### DIFF
--- a/js/AdaptiveDifficulty.js
+++ b/js/AdaptiveDifficulty.js
@@ -1,0 +1,110 @@
+/**
+ * AdaptiveDifficulty — auto-adjusts AI rubber-banding based on player performance.
+ *
+ * Tracks recent finish positions in localStorage. After each race, nudges the
+ * difficulty value toward a target that keeps the player finishing mid-pack.
+ *
+ * Difficulty is a 0-100 value where 0 = no rubber-banding, 100 = maximum.
+ */
+
+const STORAGE_KEY = 'racing-adaptive-difficulty';
+const HISTORY_SIZE = 5;
+const STEP_SIZE = 8; // difficulty points per adjustment
+
+export class AdaptiveDifficulty {
+
+	constructor( settings ) {
+
+		this._settings = settings;
+		this._history = [];
+		this._load();
+
+	}
+
+	/**
+	 * Called after a race finishes.
+	 * @param {number} position - Player's finish position (1-based)
+	 * @param {number} totalRacers - Total racers in the race
+	 */
+	recordFinish( position, totalRacers ) {
+
+		if ( totalRacers < 2 ) return;
+
+		// Normalize position to 0-1 (0 = first, 1 = last)
+		const normalized = ( position - 1 ) / ( totalRacers - 1 );
+		this._history.push( normalized );
+
+		if ( this._history.length > HISTORY_SIZE ) {
+
+			this._history.shift();
+
+		}
+
+		this._save();
+		this._adjust();
+
+	}
+
+	_adjust() {
+
+		if ( this._history.length < 2 ) return;
+
+		// Average recent finish position (0 = always first, 1 = always last)
+		const avg = this._history.reduce( ( a, b ) => a + b, 0 ) / this._history.length;
+
+		// Target: finish around 0.3-0.5 (2nd-3rd out of 5-6 racers)
+		const current = this._settings.get( 'difficulty' ) ?? 50;
+		let next = current;
+
+		if ( avg < 0.2 ) {
+
+			// Player dominates — reduce rubber-banding (make it harder)
+			next = Math.max( 0, current - STEP_SIZE );
+
+		} else if ( avg > 0.6 ) {
+
+			// Player struggles — increase rubber-banding (make it easier)
+			next = Math.min( 100, current + STEP_SIZE );
+
+		}
+
+		// No change if player is in the sweet spot (0.2-0.6)
+
+		if ( next !== current ) {
+
+			this._settings.set( 'difficulty', next );
+
+		}
+
+	}
+
+	_load() {
+
+		try {
+
+			const raw = localStorage.getItem( STORAGE_KEY );
+			if ( raw ) this._history = JSON.parse( raw );
+
+		} catch {
+
+			this._history = [];
+
+		}
+
+	}
+
+	_save() {
+
+		try {
+
+			localStorage.setItem( STORAGE_KEY, JSON.stringify( this._history ) );
+
+		} catch {
+
+			// localStorage full or unavailable
+
+		}
+
+	}
+
+}

--- a/js/main.js
+++ b/js/main.js
@@ -32,6 +32,7 @@ import { CombatManager } from './CombatManager.js';
 import { DamageSFX } from './DamageSFX.js';
 import { DamageVFX } from './DamageVFX.js';
 import { HUDDamage } from './HUDDamage.js';
+import { AdaptiveDifficulty } from './AdaptiveDifficulty.js';
 import { ProjectileManager } from './ProjectileManager.js';
 import { ItemSlotManager } from './ItemSlotManager.js';
 import { rollItem } from './PowerupItem.js';
@@ -555,6 +556,7 @@ async function init() {
 
 	const settings = new Settings();
 	const adaptiveQuality = new AdaptiveQuality( settings );
+	const adaptiveDifficulty = new AdaptiveDifficulty( settings );
 
 	// Apply custom vehicle/character colors from settings
 	applyPlayerTints( vehicle, settings );
@@ -867,6 +869,7 @@ async function init() {
 
 	let lastFrameTime = 0;
 	let shadowFrameCounter = 0;
+	let _prevRaceState = 'idle';
 
 	function animate() {
 
@@ -1082,10 +1085,21 @@ async function init() {
 
 		}
 
-		hud.update( dt, raceMode.getDisplayState(), raceLobby.getDisplayState() );
+		const _rds = raceMode.getDisplayState();
+		hud.update( dt, _rds, raceLobby.getDisplayState() );
+
+		// Adaptive difficulty — record finish position on race end
+		if ( _rds.state === 'finished' && _prevRaceState !== 'finished' ) {
+
+			adaptiveDifficulty.recordFinish( _rds.position, allActiveVehicles.length );
+
+		}
+
+		_prevRaceState = _rds.state;
+
 		if ( ! spectating && vehicle ) hudDamage.update( vehicle.health, vehicle.itemSlot ? vehicle.itemSlot.heldItemId : null, dt );
 		speedometer.update( dt, vehicle.linearSpeed, vehicle.momentum, vehicle.boostActive, vehicle.effectiveTopSpeed, vehicle.debug.topSpeed );
-		minimap.update( allActiveVehicles, raceMode.getDisplayState().state );
+		minimap.update( allActiveVehicles, _rds.state );
 
 		// Send local state to server (throttled internally at 20Hz)
 		if ( multiplayer && network.connected && ! spectating ) {


### PR DESCRIPTION
Auto-adjusts AI rubber-banding between races based on how the player has been performing. Tracks the last 5 finish positions (normalized 0-1) in localStorage and nudges the difficulty setting in 8-point steps:

- **Player dominates** (avg top 20%) — reduces rubber-banding, making AI less forgiving
- **Player struggles** (avg bottom 40%) — increases rubber-banding, helping the player compete
- **Mid-pack** (20-60%) — no adjustment, races feel competitive

Hooks into the existing `Settings.onChange` pipeline, so `aiManager.rubberBandIntensity` updates automatically. Detects the racing→finished state transition in the game loop to trigger recording.

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)