### PR TITLE
feat: ghost split-time delta HUD during races

### DIFF
--- a/js/GhostPlayer.js
+++ b/js/GhostPlayer.js
@@ -155,6 +155,16 @@ export class GhostPlayer {
 	}
 
 	/**
+	 * Get the ghost's current world position, or null if not active.
+	 */
+	get currentPosition() {
+
+		if ( ! this._loaded || ! this._mesh || ! this._visible ) return null;
+		return this._mesh.position;
+
+	}
+
+	/**
 	 * Whether a ghost recording is loaded.
 	 */
 	get hasGhost() {

--- a/js/main.js
+++ b/js/main.js
@@ -650,6 +650,16 @@ async function init() {
 	].join( ';' );
 	document.body.appendChild( ghostHudEl );
 
+	// Ghost split delta HUD element
+	const ghostDeltaEl = document.createElement( 'div' );
+	ghostDeltaEl.style.cssText = [
+		'position:fixed', 'top:80px', 'left:50%', 'transform:translateX(-50%)',
+		'font:bold 18px/1 monospace',
+		'z-index:1000', 'pointer-events:none', 'user-select:none', 'display:none',
+		'transition:opacity 0.3s',
+	].join( ';' );
+	document.body.appendChild( ghostDeltaEl );
+
 	if ( ghostPlayer.hasGhost ) {
 
 		const gt = ghostPlayer.lapTime;
@@ -1065,6 +1075,36 @@ async function init() {
 			if ( ghostHudEl.style.display === 'none' && settings.get( 'ghostEnabled' ) !== false ) {
 
 				ghostHudEl.style.display = 'block';
+
+			}
+
+			// Ghost split delta — compare track progress between player and ghost
+			if ( raceMode.state === 'racing' && trackIntel && trackIntel.valid && ghostPlayer.currentPosition ) {
+
+				const playerProgress = trackIntel.getProgress( vehicle.vehPos.x, vehicle.vehPos.z );
+				const gPos = ghostPlayer.currentPosition;
+				const ghostProgress = trackIntel.getProgress( gPos.x, gPos.z );
+
+				// Time delta: positive = player is behind ghost, negative = player is ahead
+				const progressDelta = ghostProgress - playerProgress;
+				const timeDelta = progressDelta * ghostPlayer.lapTime;
+
+				if ( Math.abs( timeDelta ) < 30 ) {
+
+					const sign = timeDelta > 0 ? '+' : '';
+					ghostDeltaEl.textContent = `${ sign }${ timeDelta.toFixed( 1 ) }s`;
+					ghostDeltaEl.style.color = timeDelta > 0 ? '#ff4444' : '#44ff44';
+					ghostDeltaEl.style.display = 'block';
+
+				} else {
+
+					ghostDeltaEl.style.display = 'none';
+
+				}
+
+			} else {
+
+				ghostDeltaEl.style.display = 'none';
 
 			}
 


### PR DESCRIPTION
Shows a real-time split-time delta when racing against your ghost replay. Displays "+1.2s" in red when behind and "-0.8s" in green when ahead.

Computes the delta by comparing TrackIntel waypoint progress between the player's current position and the ghost's interpolated position, then multiplying the progress difference by the ghost's recorded lap time. Hidden when no ghost is loaded, when not racing, or when the delta is unreasonably large (>30s, indicating a progress wrap).

- **GhostPlayer.js**: Added `currentPosition` getter exposing the ghost mesh position
- **main.js**: Added ghost delta HUD element and per-frame delta computation in the ghost update block

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)