### PR TITLE
feat: auto-generate track thumbnails on editor save

### DIFF
--- a/js/editor/Persistence.js
+++ b/js/editor/Persistence.js
@@ -147,7 +147,7 @@ export function getSavedTracks() {
 
 }
 
-export function saveNamedTrack( grid, name ) {
+export function saveNamedTrack( grid, name, thumbnail ) {
 
 	const tracks = getSavedTracks();
 	const encoded = encodeCells( getCellsArray( grid ) );
@@ -159,6 +159,8 @@ export function saveNamedTrack( grid, name ) {
 		pieces: grid.size,
 		date: new Date().toLocaleDateString()
 	};
+
+	if ( thumbnail ) entry.thumbnail = thumbnail;
 
 	if ( existing >= 0 ) {
 

--- a/js/editor/editor-main.js
+++ b/js/editor/editor-main.js
@@ -68,7 +68,12 @@ const cycleElevation = ( gx, gz ) => _cycleElevation( { grid, placeMesh, pushUnd
 const getCellsArray = () => _getCellsArray( grid );
 const save = () => _save( grid );
 const loadSaved = () => _loadSaved( { grid, placeMesh, deriveRampsFromElevation, deriveAllCurves } );
-const saveNamedTrack = ( name ) => _saveNamedTrack( grid, name );
+const saveNamedTrack = ( name ) => {
+
+	const thumbnail = generateThumbnail();
+	_saveNamedTrack( grid, name, thumbnail );
+
+};
 const loadNamedTrack = ( encoded ) => _loadNamedTrack( { grid, trackGroup, placeMesh, pushUndo, save, updateStats, updateFinishCar, deriveRampsFromElevation, deriveAllCurves }, encoded );
 const updateDebugTooltip = ( gx, gz, clientX, clientY ) => _updateDebugTooltip( grid, trackTileSet, gx, gz, clientX, clientY );
 const resolveCellAndNeighbors = ( gx, gz ) => _resolveCellAndNeighbors( grid, models, trackGroup, gx, gz, renderCurves );
@@ -211,6 +216,55 @@ const camera = new THREE.OrthographicCamera(
 );
 const cellCenter = 0.5 * CELL_RAW * GRID_SCALE;
 const camTarget = new THREE.Vector3( cellCenter, 0, cellCenter );
+
+// ─── Track thumbnail generator ───────────────────────────
+
+function generateThumbnail() {
+
+	try {
+
+		// Compute bounding box of placed track tiles
+		const box = new THREE.Box3();
+		trackGroup.traverse( ( child ) => {
+
+			if ( child.isMesh ) box.expandByObject( child );
+
+		} );
+
+		if ( box.isEmpty() ) return null;
+
+		const center = box.getCenter( new THREE.Vector3() );
+		const size = box.getSize( new THREE.Vector3() );
+		const extent = Math.max( size.x, size.z ) * 0.6;
+
+		// Set up temporary orthographic camera looking straight down
+		const thumbCam = new THREE.OrthographicCamera(
+			- extent, extent, extent, - extent, 0.1, 200
+		);
+		thumbCam.position.set( center.x, 80, center.z );
+		thumbCam.lookAt( center.x, 0, center.z );
+		thumbCam.updateMatrixWorld();
+
+		// Render to a small target
+		const prevSize = renderer.getSize( new THREE.Vector2() );
+		renderer.setSize( 160, 160, false );
+		renderer.render( scene, thumbCam );
+
+		// Capture as data URL
+		const dataUrl = renderer.domElement.toDataURL( 'image/jpeg', 0.6 );
+
+		// Restore original size
+		renderer.setSize( prevSize.x, prevSize.y, false );
+
+		return dataUrl;
+
+	} catch {
+
+		return null;
+
+	}
+
+}
 
 // ─── Orbit / tilt / height state ──────────────────────────
 
@@ -1685,6 +1739,18 @@ document.getElementById( 'btn-load' ).addEventListener( 'click', () => {
 		for ( const t of tracks ) {
 
 			const li = document.createElement( 'li' );
+			li.style.display = 'flex';
+			li.style.alignItems = 'center';
+			li.style.gap = '10px';
+
+			if ( t.thumbnail ) {
+
+				const thumb = document.createElement( 'img' );
+				thumb.src = t.thumbnail;
+				thumb.style.cssText = 'width:48px; height:48px; border-radius:4px; object-fit:cover; flex-shrink:0';
+				li.appendChild( thumb );
+
+			}
 
 			const info = document.createElement( 'div' );
 			info.innerHTML = `<div class="track-name">${ t.name }</div><div class="track-meta">${ t.pieces } pieces &middot; ${ t.date }</div>`;


### PR DESCRIPTION
Generates a top-down orthographic thumbnail (160x160 JPEG, ~5KB) when saving a track in the editor. The thumbnail captures the full track extent from above and is stored as a data URL in localStorage alongside the track data.

The load track dialog now displays thumbnails next to track names, transforming the text-only track list into a visual gallery. Thumbnails make it easy to identify tracks at a glance when you have multiple saves.

**How it works:**
1. On save, computes the bounding box of all track tiles
2. Creates a temporary orthographic camera positioned above the center
3. Renders at 160x160, captures via `toDataURL('image/jpeg', 0.6)`
4. Restores original renderer size
5. Stores the data URL in the track entry's `thumbnail` field

Gracefully handles empty tracks (returns null) and renderer errors (try/catch). Thumbnails are optional — tracks saved before this change display without them.

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)