### PR TITLE
feat: camera mode HUD indicator and mobile cycle button

### DIFF
--- a/js/Camera.js
+++ b/js/Camera.js
@@ -541,6 +541,8 @@ export class Camera {
 		else if ( this.mode === 'dashboard' ) this.mode = 'isometric';
 		else if ( this.mode === 'isometric' ) this.mode = 'chase';
 
+		if ( this.onModeChange ) this.onModeChange( this.mode );
+
 	}
 
 	getVelocity() {

--- a/js/Controls.js
+++ b/js/Controls.js
@@ -279,6 +279,23 @@ export class Controls {
 		btnZone.appendChild( itemBtn );
 		container.appendChild( btnZone );
 
+		// Camera cycle button (top-left, separate from action zone)
+		const camBtn = document.createElement( 'div' );
+		camBtn.textContent = 'CAM';
+		camBtn.style.cssText = [
+			'position:fixed', 'top:16px', 'left:16px', 'width:48px', 'height:48px',
+			'background:rgba(255,255,255,0.15)', 'color:#fff', 'font:bold 12px/48px monospace',
+			'text-align:center', 'border-radius:50%', 'z-index:1000',
+			'touch-action:none', 'user-select:none',
+		].join( ';' );
+		camBtn.addEventListener( 'pointerdown', ( e ) => {
+
+			e.preventDefault();
+			if ( this.camera ) this.camera.cycleMode();
+
+		} );
+		container.appendChild( camBtn );
+
 		document.body.appendChild( container );
 		this._touchContainer = container;
 

--- a/js/HUD.js
+++ b/js/HUD.js
@@ -54,6 +54,18 @@ export class HUD {
 		this._raceHud.appendChild( this._timeLine );
 		document.body.appendChild( this._raceHud );
 
+		// ── Camera mode toast ────────────────────────────────────────────────
+		this._cameraModeEl = document.createElement( 'div' );
+		this._cameraModeEl.style.cssText = [
+			'position:fixed', 'bottom:80px', 'left:50%', 'transform:translateX(-50%)',
+			'background:rgba(0,0,0,0.65)', 'color:#fff', 'font:bold 14px/1 monospace',
+			'padding:6px 14px', 'border-radius:6px', 'z-index:1001',
+			'pointer-events:none', 'user-select:none', 'display:none',
+			'transition:opacity 0.3s',
+		].join( ';' );
+		document.body.appendChild( this._cameraModeEl );
+		this._cameraModeTimer = 0;
+
 		// ── Results overlay (centered panel) ─────────────────────────────────
 		this._resultsEl = document.createElement( 'div' );
 		this._resultsEl.style.cssText = [
@@ -262,6 +274,20 @@ export class HUD {
 
 		}
 
+		// Camera mode toast fade
+		if ( this._cameraModeTimer > 0 ) {
+
+			this._cameraModeTimer -= dt;
+
+			if ( this._cameraModeTimer <= 0 ) {
+
+				this._cameraModeEl.style.opacity = '0';
+				setTimeout( () => { this._cameraModeEl.style.display = 'none'; }, 300 );
+
+			}
+
+		}
+
 	}
 
 	_updateLobby( lobbyState ) {
@@ -400,6 +426,23 @@ export class HUD {
 			this._powerupEl.style.display = 'none';
 
 		}
+
+	}
+
+	showCameraMode( modeName ) {
+
+		const labels = {
+			chase: 'CHASE CAM',
+			cockpit: 'COCKPIT',
+			dashboard: 'DASHBOARD',
+			isometric: 'ISOMETRIC',
+			topdown: 'TOP DOWN',
+		};
+
+		this._cameraModeEl.textContent = labels[ modeName ] || modeName.toUpperCase();
+		this._cameraModeEl.style.display = 'block';
+		this._cameraModeEl.style.opacity = '1';
+		this._cameraModeTimer = 1.5;
 
 	}
 

--- a/js/main.js
+++ b/js/main.js
@@ -546,6 +546,7 @@ async function init() {
 
 	const cam = new Camera();
 	cam.targetPosition.copy( vehicle.vehPos );
+	cam.onModeChange = ( mode ) => hud.showCameraMode( mode );
 
 	const rearview = new RearviewMirror( renderer );
 


### PR DESCRIPTION
Shows a brief toast when cycling camera modes (chase, cockpit, dashboard, isometric) so players know which view is active. Adds a CAM button in the top-left corner for mobile players who previously had no way to change cameras (C key is desktop-only).

**Changes:**
- Camera.js: `onModeChange` callback fires after `cycleMode()`
- HUD.js: `showCameraMode()` displays a 1.5s fade-out toast with mode label
- Controls.js: CAM touch button in top-left, triggers `camera.cycleMode()`
- main.js: Wires Camera callback to HUD

---

🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)