### PR TITLE
feat: track export/import to .json files

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -90,6 +90,12 @@
 			<button id="btn-load" data-tip="Load">
 				<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 14 1.5-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.54 6a2 2 0 0 1-1.95 1.5H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.67.9H18a2 2 0 0 1 2 2v2"/></svg>
 			</button>
+			<button id="btn-export" data-tip="Export file">
+				<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+			</button>
+			<button id="btn-import" data-tip="Import file">
+				<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" x2="12" y1="3" y2="15"/></svg>
+			</button>
 			<div class="separator"></div>
 			<button id="btn-validate" data-tip="Validate">
 				<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.801 10A10 10 0 1 1 17 3.335"/><path d="m9 11 3 3L22 4"/></svg>

--- a/js/editor/Persistence.js
+++ b/js/editor/Persistence.js
@@ -182,6 +182,72 @@ export function saveNamedTrack( grid, name ) {
 
 }
 
+/**
+ * Export current grid to a downloadable .json file.
+ */
+export function exportToFile( grid, trackName ) {
+
+	const encoded = encodeCells( getCellsArray( grid ) );
+	const data = {
+		version: 1,
+		name: trackName || 'Untitled Track',
+		cells: encoded,
+		pieces: grid.size,
+		exportedAt: new Date().toISOString(),
+	};
+
+	const blob = new Blob( [ JSON.stringify( data, null, 2 ) ], { type: 'application/json' } );
+	const url = URL.createObjectURL( blob );
+	const a = document.createElement( 'a' );
+	a.href = url;
+	a.download = ( trackName || 'track' ).replace( /[^a-zA-Z0-9_-]/g, '_' ) + '.json';
+	a.click();
+	URL.revokeObjectURL( url );
+
+}
+
+/**
+ * Import a track from a .json file.
+ * @param {File} file
+ * @returns {Promise<{name: string, cells: string}|null>}
+ */
+export function importFromFile( file ) {
+
+	return new Promise( ( resolve ) => {
+
+		const reader = new FileReader();
+		reader.onload = () => {
+
+			try {
+
+				const data = JSON.parse( reader.result );
+
+				if ( ! data.cells || typeof data.cells !== 'string' ) {
+
+					console.warn( 'Invalid track file: missing cells data' );
+					resolve( null );
+					return;
+
+				}
+
+				resolve( { name: data.name || file.name.replace( /\.json$/, '' ), cells: data.cells } );
+
+			} catch ( e ) {
+
+				console.warn( 'Failed to parse track file:', e.message );
+				resolve( null );
+
+			}
+
+		};
+
+		reader.onerror = () => resolve( null );
+		reader.readAsText( file );
+
+	} );
+
+}
+
 export function deleteNamedTrack( name ) {
 
 	const tracks = getSavedTracks().filter( t => t.name !== name );

--- a/js/editor/editor-main.js
+++ b/js/editor/editor-main.js
@@ -37,6 +37,8 @@ import {
 	saveNamedTrack as _saveNamedTrack,
 	deleteNamedTrack,
 	loadNamedTrack as _loadNamedTrack,
+	exportToFile,
+	importFromFile,
 } from './Persistence.js';
 import {
 	initDebugMode,
@@ -1734,6 +1736,51 @@ document.getElementById( 'load-cancel' ).addEventListener( 'click', () => {
 	modalLoad.classList.add( 'hidden' );
 
 } );
+
+// ── Export current track to file ─────────────────────────────────────
+const exportBtn = document.getElementById( 'btn-export' );
+if ( exportBtn ) {
+
+	exportBtn.addEventListener( 'click', () => {
+
+		if ( grid.size === 0 ) { showToast( 'Draw some road first!' ); return; }
+
+		// Try to use the last saved track name, else 'track'
+		const tracks = getSavedTracks();
+		const lastName = tracks.length > 0 ? tracks[ 0 ].name : 'track';
+		exportToFile( grid, lastName );
+		showToast( 'Track exported!' );
+
+	} );
+
+}
+
+// ── Import track from file ───────────────────────────────────────────
+const importBtn = document.getElementById( 'btn-import' );
+if ( importBtn ) {
+
+	importBtn.addEventListener( 'click', () => {
+
+		const input = document.createElement( 'input' );
+		input.type = 'file';
+		input.accept = '.json';
+		input.addEventListener( 'change', async () => {
+
+			if ( ! input.files || input.files.length === 0 ) return;
+			const result = await importFromFile( input.files[ 0 ] );
+
+			if ( ! result ) { showToast( 'Invalid track file' ); return; }
+
+			loadNamedTrack( result.cells );
+			showToast( `Imported "${ result.name }"` );
+
+		} );
+
+		input.click();
+
+	} );
+
+}
 
 // Close modals on overlay click
 modalSave.addEventListener( 'click', ( e ) => {


### PR DESCRIPTION
Adds export and import buttons to the editor toolbar. Tracks can be downloaded as versioned .json files and loaded back, protecting player-created content against localStorage loss.

**Export:** Downloads a .json file containing the encoded cells, track name, piece count, and export timestamp. Filename is derived from the track name.

**Import:** Opens a file picker, validates the JSON structure, and loads the track into the editor via the existing `loadNamedTrack` path.

---

🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)