### PR TITLE
feat: audio feedback for boost end and drift stage transitions

### DIFF
--- a/js/Audio.js
+++ b/js/Audio.js
@@ -406,6 +406,75 @@ export class GameAudio {
 
 	}
 
+	playBoostEnd() {
+
+		if ( ! this.listener ) return;
+
+		const ctx = this.listener.context;
+		if ( ! ctx || ctx.state === 'suspended' ) return;
+
+		try {
+
+			const osc = ctx.createOscillator();
+			const gain = ctx.createGain();
+
+			osc.type = 'sawtooth';
+			osc.frequency.setValueAtTime( 500, ctx.currentTime );
+			osc.frequency.exponentialRampToValueAtTime( 150, ctx.currentTime + 0.3 );
+
+			gain.gain.setValueAtTime( 0.3, ctx.currentTime );
+			gain.gain.exponentialRampToValueAtTime( 0.001, ctx.currentTime + 0.3 );
+
+			osc.connect( gain );
+			gain.connect( this._sfxGain );
+
+			osc.start( ctx.currentTime );
+			osc.stop( ctx.currentTime + 0.3 );
+
+		} catch {
+
+			// Silently fail if audio context not ready
+
+		}
+
+	}
+
+	playDriftStageUp( stage ) {
+
+		if ( ! this.listener ) return;
+
+		const ctx = this.listener.context;
+		if ( ! ctx || ctx.state === 'suspended' ) return;
+
+		// Rising pitch per drift tier: stage 1 = 500Hz, 2 = 700Hz, 3 = 900Hz
+		const freq = 300 + stage * 200;
+
+		try {
+
+			const osc = ctx.createOscillator();
+			const gain = ctx.createGain();
+
+			osc.type = 'sine';
+			osc.frequency.setValueAtTime( freq, ctx.currentTime );
+			osc.frequency.linearRampToValueAtTime( freq * 1.2, ctx.currentTime + 0.1 );
+
+			gain.gain.setValueAtTime( 0.2, ctx.currentTime );
+			gain.gain.exponentialRampToValueAtTime( 0.001, ctx.currentTime + 0.15 );
+
+			osc.connect( gain );
+			gain.connect( this._sfxGain );
+
+			osc.start( ctx.currentTime );
+			osc.stop( ctx.currentTime + 0.15 );
+
+		} catch {
+
+			// Silently fail if audio context not ready
+
+		}
+
+	}
+
 	playShieldBreak() {
 
 		if ( ! this.listener ) return;

--- a/js/main.js
+++ b/js/main.js
@@ -1014,19 +1014,26 @@ async function init() {
 
 			}
 
-			if ( boostJustEnded && vehicle.underglowLight ) {
+			if ( boostJustEnded ) {
 
-				vehicle.underglowLight.visible = false;
-				vehicle.underglowLight.color.setHex( 0x00ffff );
+				audio.playBoostEnd();
+
+				if ( vehicle.underglowLight ) {
+
+					vehicle.underglowLight.visible = false;
+					vehicle.underglowLight.color.setHex( 0x00ffff );
+
+				}
 
 			}
 
 			wasBoostActive = vehicle.boostActive;
 
-			// Drift stage transition haptic pulse
+			// Drift stage transition haptic + audio
 			if ( vehicle.driftStage !== prevDriftStage && vehicle.driftStage > prevDriftStage ) {
 
 				haptics.pulse();
+				audio.playDriftStageUp( vehicle.driftStage );
 
 			}
 


### PR DESCRIPTION
Adds synthesized audio cues for two previously silent gameplay moments:

- **Boost end:** Descending sawtooth sweep (500→150Hz over 0.3s), the inverse of the existing boost-start whoosh
- **Drift stage up:** Rising sine beep with pitch increasing per drift tier (500/700/900Hz), giving players audio confirmation of drift charge progression

Both follow the existing Web Audio oscillator pattern used by `playBoostWhoosh()` and `playLapChime()`.

---

🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)