### PR TITLE
chore: remove unused Nav imports from settings and tutorial controllers

### DIFF
--- a/js/ui/pages/page21-settings/Page21SettingsController.js
+++ b/js/ui/pages/page21-settings/Page21SettingsController.js
@@ -33,7 +33,6 @@ import { Page21SettingsView }    from './Page21SettingsView.js';
 import { RouteIds }              from '../../enums/RouteIds.js';
 import { PageIds }               from '../../enums/PageIds.js';
 import { EventIds }              from '../../enums/EventIds.js';
-import * as Nav                  from '../../core/NavigationService.js';
 
 /** Map URL hash fragments to Tabs activeId values. */
 const HASH_TO_TAB = Object.freeze( {

--- a/js/ui/pages/page23-tutorial/Page23TutorialController.js
+++ b/js/ui/pages/page23-tutorial/Page23TutorialController.js
@@ -31,7 +31,6 @@ import { Page23TutorialView }    from './Page23TutorialView.js';
 import { RouteIds }              from '../../enums/RouteIds.js';
 import { PageIds }               from '../../enums/PageIds.js';
 import { EventIds }              from '../../enums/EventIds.js';
-import * as Nav                  from '../../core/NavigationService.js';
 
 /** localStorage key for tutorial completion flag. */
 const TUTORIAL_COMPLETE_KEY = 'kk:tutorial:complete';


### PR DESCRIPTION
Both Page21SettingsController and Page23TutorialController imported `NavigationService` as `Nav` but never used it — they route through `this.navigateBack()` / `this.navigate()` inherited from PageControllerBase instead.

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)