### PR TITLE
fix: auto-respawn when vehicle falls into void below track

### DIFF
--- a/js/Vehicle.js
+++ b/js/Vehicle.js
@@ -16,6 +16,9 @@ const _quat = new THREE.Quaternion();
 
 export const DrivingState = { NORMAL: 0, DRIFTING: 1, AIRBORNE: 2 };
 
+/** Vehicles below this Y height trigger an automatic respawn (safety-net is at Y=-5). */
+const KILL_PLANE_Y = - 3;
+
 function lerpAngle( a, b, t ) {
 
 	let diff = b - a;
@@ -900,7 +903,7 @@ export class Vehicle {
 		}
 
 		// Kill plane and full flip are instant respawn (no grace period)
-		const killPlaneHit = this.groundHeight < - 10;
+		const killPlaneHit = this.groundHeight < KILL_PLANE_Y;
 		const flipRespawn = this._flipStatus === 'respawn';
 		const respawnRequested = killPlaneHit || flipRespawn ||
 			( this._offTrackTimer > this._offTrackGrace );


### PR DESCRIPTION
Raises the kill-plane threshold from Y=-10 to Y=-3 so vehicles that fall off the track trigger an automatic respawn before reaching the safety-net ground plane at Y=-5. Previously vehicles would land on the invisible floor and slide around with no way to return to the track.

Extracts the threshold to a named `KILL_PLANE_Y` constant for clarity.

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)