### PR TITLE
feat: persistent race stats with NEW RECORD display

### DIFF
--- a/js/HUD.js
+++ b/js/HUD.js
@@ -70,6 +70,15 @@ export class HUD {
 		this._resultsTotalLine = document.createElement( 'div' );
 		this._resultsBestLine = document.createElement( 'div' );
 
+		this._resultsPrevBestLine = document.createElement( 'div' );
+		this._resultsPrevBestLine.style.cssText = 'color:#aaa; font-size:16px; margin-top:4px';
+
+		this._resultsRecordLine = document.createElement( 'div' );
+		this._resultsRecordLine.style.cssText = [
+			'color:#ffdd00', 'font-size:28px', 'margin-top:12px',
+			'animation:kk-record-pulse 0.6s ease-in-out infinite alternate',
+		].join( ';' );
+
 		this._restartBtn = document.createElement( 'button' );
 		this._restartBtn.textContent = 'RESTART';
 		this._restartBtn.style.cssText = [
@@ -86,8 +95,20 @@ export class HUD {
 		this._resultsEl.appendChild( this._resultsTitle );
 		this._resultsEl.appendChild( this._resultsTotalLine );
 		this._resultsEl.appendChild( this._resultsBestLine );
+		this._resultsEl.appendChild( this._resultsPrevBestLine );
+		this._resultsEl.appendChild( this._resultsRecordLine );
 		this._resultsEl.appendChild( this._restartBtn );
 		document.body.appendChild( this._resultsEl );
+
+		// Keyframe animation for NEW RECORD pulse
+		if ( ! document.getElementById( 'kk-record-pulse-style' ) ) {
+
+			const style = document.createElement( 'style' );
+			style.id = 'kk-record-pulse-style';
+			style.textContent = '@keyframes kk-record-pulse { from { opacity:1; transform:scale(1); } to { opacity:0.7; transform:scale(1.05); } }';
+			document.head.appendChild( style );
+
+		}
 
 		// ── Boost meter bar ──────────────────────────────────────────────────
 		this._boostContainer = document.createElement( 'div' );
@@ -249,7 +270,8 @@ export class HUD {
 				this._updatePowerupIndicator( dt, displayState );
 				break;
 
-			case 'finished':
+			case 'finished': {
+
 				this._lobbyPanel.style.display = 'none';
 				this._countdownEl.style.display = 'none';
 				this._raceHud.style.display = 'none';
@@ -258,7 +280,35 @@ export class HUD {
 				this._resultsEl.style.display = 'block';
 				this._resultsTotalLine.textContent = `Total: ${ this._formatTime( displayState.totalTime ) }`;
 				this._resultsBestLine.textContent = `Best Lap: ${ this._formatTime( displayState.bestLap ) }`;
+
+				const stats = displayState.raceStatsResult;
+				if ( stats ) {
+
+					const isNewRecord = stats.newBestLap || stats.newBestTotal;
+					this._resultsRecordLine.textContent = isNewRecord ? 'NEW RECORD!' : '';
+					this._resultsRecordLine.style.display = isNewRecord ? 'block' : 'none';
+
+					if ( stats.prevBestTotal > 0 ) {
+
+						this._resultsPrevBestLine.textContent = `Previous Best: ${ this._formatTime( stats.prevBestTotal ) }`;
+						this._resultsPrevBestLine.style.display = 'block';
+
+					} else {
+
+						this._resultsPrevBestLine.style.display = 'none';
+
+					}
+
+				} else {
+
+					this._resultsRecordLine.style.display = 'none';
+					this._resultsPrevBestLine.style.display = 'none';
+
+				}
+
 				break;
+
+			}
 
 		}
 

--- a/js/RaceStats.js
+++ b/js/RaceStats.js
@@ -1,0 +1,80 @@
+const KEY_PREFIX = 'race-stats:';
+const SCHEMA_VERSION = 1;
+
+/**
+ * Save race results for a track. Compares against existing bests and
+ * returns which records were broken.
+ *
+ * @param {string} trackId
+ * @param {{ totalTime: number, bestLap: number, laps: number }} results
+ * @returns {{ newBestLap: boolean, newBestTotal: boolean, prevBestLap: number, prevBestTotal: number }}
+ */
+export function saveRaceStats( trackId, results ) {
+
+	const existing = loadRaceStats( trackId );
+
+	const prevBestLap = existing ? existing.bestLap : Infinity;
+	const prevBestTotal = existing ? existing.bestTotal : Infinity;
+
+	const newBestLap = results.bestLap > 0 && results.bestLap < prevBestLap;
+	const newBestTotal = results.totalTime > 0 && results.totalTime < prevBestTotal;
+
+	// Coerce Infinity to 0 before JSON serialization (Infinity → null in JSON)
+	const safePrevLap = prevBestLap === Infinity ? 0 : prevBestLap;
+	const safePrevTotal = prevBestTotal === Infinity ? 0 : prevBestTotal;
+
+	const data = {
+		_version: SCHEMA_VERSION,
+		bestLap: newBestLap ? results.bestLap : safePrevLap,
+		bestTotal: newBestTotal ? results.totalTime : safePrevTotal,
+		raceCount: ( existing ? existing.raceCount : 0 ) + 1,
+	};
+
+	try {
+
+		localStorage.setItem( KEY_PREFIX + trackId, JSON.stringify( data ) );
+
+	} catch ( e ) {
+
+		// localStorage quota exceeded — fail silently
+
+	}
+
+	return {
+		newBestLap,
+		newBestTotal,
+		prevBestLap: safePrevLap,
+		prevBestTotal: safePrevTotal,
+	};
+
+}
+
+/**
+ * Load persisted race stats for a track.
+ *
+ * @param {string} trackId
+ * @returns {{ bestLap: number, bestTotal: number, raceCount: number } | null}
+ */
+export function loadRaceStats( trackId ) {
+
+	try {
+
+		const raw = localStorage.getItem( KEY_PREFIX + trackId );
+		if ( ! raw ) return null;
+
+		const data = JSON.parse( raw );
+		if ( typeof data.bestLap !== 'number' || typeof data.bestTotal !== 'number' ) return null;
+
+		return {
+			bestLap: data.bestLap,
+			bestTotal: data.bestTotal,
+			raceCount: data.raceCount || 0,
+		};
+
+	} catch ( e ) {
+
+		return null;
+
+	}
+
+}

--- a/js/main.js
+++ b/js/main.js
@@ -48,6 +48,7 @@ import { RearviewMirror } from './RearviewMirror.js';
 import { GhostRecorder } from './GhostRecorder.js';
 import { GhostPlayer } from './GhostPlayer.js';
 import { getTrackId } from './GhostStorage.js';
+import { saveRaceStats, loadRaceStats } from './RaceStats.js';
 
 
 const SPECTATE_INPUT = { x: 0, z: 0, touchActive: false, boost: false, gas: false, brake: false };
@@ -441,7 +442,7 @@ async function init() {
 	} );
 
 	const hud = new HUD(
-		() => { raceMode.reset(); aiManager.resetRace(); raceLobby.reset(); },
+		() => { raceMode.reset(); aiManager.resetRace(); raceLobby.reset(); raceStatsResult = null; },
 		() => raceLobby.setReady( playerManager.localId )
 	);
 
@@ -631,8 +632,12 @@ async function init() {
 
 	}
 
+	// ── Race stats persistence ─────────────────────────────────────────────
+	const raceStatsTrackId = getTrackId( activeCells );
+	let raceStatsResult = null; // set once on finish
+
 	// ── Ghost replay setup ──────────────────────────────────────────────────
-	const ghostTrackId = getTrackId( activeCells );
+	const ghostTrackId = raceStatsTrackId;
 	const ghostRecorder = new GhostRecorder();
 	ghostRecorder.init( ghostTrackId );
 
@@ -1082,7 +1087,18 @@ async function init() {
 
 		}
 
-		hud.update( dt, raceMode.getDisplayState(), raceLobby.getDisplayState() );
+		// ── Save race stats on finish transition ───────────────────────
+		const ds = raceMode.getDisplayState();
+		if ( ds.state === 'finished' && ! raceStatsResult ) {
+
+			const results = raceMode.getResults();
+			if ( results ) raceStatsResult = saveRaceStats( raceStatsTrackId, results );
+
+		}
+
+		ds.raceStatsResult = raceStatsResult;
+
+		hud.update( dt, ds, raceLobby.getDisplayState() );
 		if ( ! spectating && vehicle ) hudDamage.update( vehicle.health, vehicle.itemSlot ? vehicle.itemSlot.heldItemId : null, dt );
 		speedometer.update( dt, vehicle.linearSpeed, vehicle.momentum, vehicle.boostActive, vehicle.effectiveTopSpeed, vehicle.debug.topSpeed );
 		minimap.update( allActiveVehicles, raceMode.getDisplayState().state );


### PR DESCRIPTION
## Summary

- Adds localStorage-backed persistence for best lap time, best total time, and race count per track
- Shows "Previous Best" comparison on the results screen after completing a race
- Flashes a pulsing gold "NEW RECORD!" indicator when a personal best is broken
- New `RaceStats.js` module follows the same storage pattern as `GhostStorage.js` (keyed by FNV-1a track hash)

## How it works

On race finish, `saveRaceStats()` compares the current race results against the stored personal bests for that track. The comparison result (which records were broken, what the previous bests were) flows through `displayState.raceStatsResult` to the HUD, which shows the previous best time and a NEW RECORD animation when applicable.

First race on a track always shows NEW RECORD. Subsequent races show the previous best for comparison.

## Test plan

- Complete a race on any track — first race should show "NEW RECORD!"
- Complete a second race on the same track — should show "Previous Best: X:XX.XXX"
- Beat your previous time — should show "NEW RECORD!" again
- Restart a race — stats should reset for the new attempt
- Reload the page — previous bests should persist from localStorage

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)