### PR TITLE
feat: multiplayer connection status badge on HUD

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -373,6 +373,7 @@ async function init() {
 
 			console.log( 'Disconnected from server' );
 			multiplayer = false;
+			setConnBadge( false );
 			if ( spectateBtn ) spectateBtn.style.display = 'none';
 
 		};
@@ -383,6 +384,25 @@ async function init() {
 		playerManager.initSinglePlayer();
 
 	}
+
+	// ── Connection status badge ──────────────────────────────────────────────
+	const connBadge = document.createElement( 'div' );
+	connBadge.style.cssText = [
+		'position:fixed', 'top:8px', 'left:8px', 'z-index:900',
+		'font:bold 12px/1 monospace', 'padding:4px 8px', 'border-radius:4px',
+		'user-select:none', 'pointer-events:none', 'opacity:0.7',
+	].join( ';' );
+
+	const setConnBadge = ( online ) => {
+
+		connBadge.textContent = online ? 'ONLINE' : 'OFFLINE';
+		connBadge.style.background = online ? '#2a7' : '#666';
+		connBadge.style.color = '#fff';
+
+	};
+
+	setConnBadge( multiplayer );
+	document.body.appendChild( connBadge );
 
 	// Direct reference for debug panel compatibility
 	const vehicle = playerManager.localVehicle;


### PR DESCRIPTION
Adds a small ONLINE/OFFLINE indicator in the top-left corner showing the player's multiplayer connection state. Updates in real-time when a disconnect occurs mid-race, so players know when opponents become AI-controlled.

Previously, multiplayer connection failures and disconnects were logged only to the console with no player-facing feedback.

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)