### PR TITLE
feat: pause menu overlay with resume, restart, and mobile button

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -854,14 +854,86 @@ async function init() {
 	const draftingSystem = new DraftingSystem();
 	const draftLines = new DraftLines( scene );
 
+	// ── Pause menu overlay ──────────────────────────────────────────────────
+	const pauseOverlay = document.createElement( 'div' );
+	pauseOverlay.style.cssText = [
+		'position:fixed', 'inset:0', 'z-index:1100',
+		'background:rgba(0,0,0,0.75)', 'display:none',
+		'justify-content:center', 'align-items:center', 'flex-direction:column',
+		'font:bold 22px/1.6 monospace', 'color:#fff', 'user-select:none',
+	].join( ';' );
+
+	const pauseTitle = document.createElement( 'div' );
+	pauseTitle.textContent = 'PAUSED';
+	pauseTitle.style.cssText = 'font-size:36px; margin-bottom:24px';
+	pauseOverlay.appendChild( pauseTitle );
+
+	const makePauseBtn = ( label ) => {
+
+		const btn = document.createElement( 'button' );
+		btn.textContent = label;
+		btn.style.cssText = [
+			'font:bold 18px monospace', 'margin:6px 0', 'padding:10px 40px',
+			'background:#fff', 'color:#000', 'border:none', 'border-radius:6px',
+			'cursor:pointer', 'min-width:200px',
+		].join( ';' );
+		return btn;
+
+	};
+
+	const resumeBtn = makePauseBtn( 'RESUME' );
+	const restartPauseBtn = makePauseBtn( 'RESTART RACE' );
+
+	const togglePause = () => {
+
+		if ( raceMode.state === 'finished' ) return; // don't pause on results screen
+		gamePaused = ! gamePaused;
+		pauseOverlay.style.display = gamePaused ? 'flex' : 'none';
+
+	};
+
+	resumeBtn.addEventListener( 'click', () => {
+
+		gamePaused = false;
+		pauseOverlay.style.display = 'none';
+
+	} );
+
+	restartPauseBtn.addEventListener( 'click', () => {
+
+		gamePaused = false;
+		pauseOverlay.style.display = 'none';
+		raceMode.reset();
+		aiManager.resetRace();
+		raceLobby.reset();
+		raceStatsResult = null;
+
+	} );
+
+	pauseOverlay.appendChild( resumeBtn );
+	pauseOverlay.appendChild( restartPauseBtn );
+	document.body.appendChild( pauseOverlay );
+
+	// Mobile pause button (top-left, below connection badge)
+	const pauseBtn = document.createElement( 'button' );
+	pauseBtn.textContent = '⏸';
+	pauseBtn.style.cssText = [
+		'position:fixed', 'top:32px', 'left:8px', 'z-index:900',
+		'font-size:20px', 'width:36px', 'height:36px',
+		'background:rgba(0,0,0,0.5)', 'color:#fff', 'border:none', 'border-radius:6px',
+		'cursor:pointer', 'touch-action:manipulation',
+	].join( ';' );
+	pauseBtn.addEventListener( 'click', togglePause );
+	document.body.appendChild( pauseBtn );
+
 	document.addEventListener( 'keydown', ( e ) => {
 
-		if ( e.code === 'KeyP' ) {
+		if ( e.code === 'KeyP' || e.code === 'Escape' ) {
 
-			gamePaused = ! gamePaused;
+			e.stopPropagation();
+			togglePause();
 
 		}
-
 
 	} );
 


### PR DESCRIPTION
## Summary

- Replaces the bare `gamePaused` boolean toggle with a full-screen pause overlay
- Shows RESUME and RESTART RACE buttons in a centered dark panel
- Adds a mobile-accessible pause button (⏸) in the top-left corner
- Supports both P key and Escape key to toggle pause
- Pausing is disabled on the results screen to prevent state conflicts

Previously, pressing P would freeze the game loop with "(PAUSED)" appended to the FPS counter and no visible UI or way to restart. Mobile players had no way to pause at all.

## Test plan

- Press P during a race — overlay should appear with RESUME and RESTART buttons
- Press Escape — same behavior
- Click RESUME — game should unpause and overlay disappear
- Click RESTART RACE — should reset the race (same as results screen restart)
- Tap the ⏸ button on mobile — should trigger pause overlay
- Try pausing on the results screen — should be ignored

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)