### PR TITLE
feat: live reload dev server with file watcher

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 import { createServer } from 'http';
 import { readFile, stat } from 'fs/promises';
+import { watch } from 'fs';
 import { join, extname } from 'path';
 import { gzipSync } from 'zlib';
 import { WebSocketServer } from 'ws';
@@ -73,18 +74,30 @@ const httpServer = createServer( async ( req, res ) => {
 
 		}
 
+		// Inject live-reload script into HTML responses
+		let body = data;
+		if ( ext === '.html' ) {
+
+			const html = data.toString();
+			const idx = html.lastIndexOf( '</body>' );
+			body = Buffer.from( idx !== - 1
+				? html.slice( 0, idx ) + LIVE_RELOAD_SNIPPET + html.slice( idx )
+				: html + LIVE_RELOAD_SNIPPET );
+
+		}
+
 		// Gzip for compressible types
 		const acceptGzip = ( req.headers[ 'accept-encoding' ] || '' ).includes( 'gzip' );
 		if ( acceptGzip && COMPRESSIBLE.has( ext ) ) {
 
 			headers[ 'Content-Encoding' ] = 'gzip';
 			res.writeHead( 200, headers );
-			res.end( gzipSync( data ) );
+			res.end( gzipSync( body ) );
 
 		} else {
 
 			res.writeHead( 200, headers );
-			res.end( data );
+			res.end( body );
 
 		}
 
@@ -369,10 +382,72 @@ setInterval( () => {
 
 }, 1000 / TICK_RATE );
 
+// ── Live reload (dev only) ──────────────────────────────────────────────────
+
+const LIVE_RELOAD_PORT = parseInt( PORT ) + 1;
+const lrServer = createServer();
+const lrWss = new WebSocketServer( { server: lrServer } );
+
+const WATCH_EXTS = new Set( [ '.js', '.html', '.css' ] );
+let reloadTimeout = null;
+
+const scheduleReload = () => {
+
+	if ( reloadTimeout ) return;
+	reloadTimeout = setTimeout( () => {
+
+		reloadTimeout = null;
+		for ( const client of lrWss.clients ) {
+
+			if ( client.readyState === 1 ) client.send( 'reload' );
+
+		}
+
+	}, 150 ); // debounce 150ms
+
+};
+
+const watchDirs = [ 'js', 'css' ];
+for ( const dir of watchDirs ) {
+
+	try {
+
+		watch( join( ROOT, dir ), { recursive: true }, ( event, filename ) => {
+
+			if ( filename && WATCH_EXTS.has( extname( filename ).toLowerCase() ) ) {
+
+				scheduleReload();
+
+			}
+
+		} );
+
+	} catch { /* directory may not exist */ }
+
+}
+
+// Also watch root HTML files
+watch( ROOT, ( event, filename ) => {
+
+	if ( filename && extname( filename ).toLowerCase() === '.html' ) {
+
+		scheduleReload();
+
+	}
+
+} );
+
+lrServer.listen( LIVE_RELOAD_PORT );
+
+// ── Live reload client snippet (injected into HTML responses) ───────────────
+
+const LIVE_RELOAD_SNIPPET = `<script>(function(){var ws=new WebSocket("ws://"+location.hostname+":${LIVE_RELOAD_PORT}");ws.onmessage=function(){location.reload()};ws.onclose=function(){setTimeout(function(){location.reload()},2000)}})()</script>`;
+
 // ── Start ────────────────────────────────────────────────────────────────────
 
 httpServer.listen( PORT, () => {
 
 	console.log( `Kart Kids server running at http://localhost:${ PORT }` );
+	console.log( `Live reload active on port ${ LIVE_RELOAD_PORT }` );
 
 } );


### PR DESCRIPTION
## Summary

- Adds automatic browser reload when JS, HTML, or CSS files change during development
- Uses a separate WebSocket on port 3001 (main game server stays on 3000) for reload signals
- 150ms debounce prevents rapid reloads when multiple files change at once (e.g., save-all)
- Live-reload client script is injected into HTML responses before `</body>` — no manual script tags needed
- Watches `js/` and `css/` directories recursively, plus root HTML files

## How it works

`server.js` now starts a second lightweight WebSocket server on port 3001. `fs.watch()` monitors source directories and sends a `reload` message to all connected browsers when a watched file changes. A tiny inline script injected into HTML pages connects to this WebSocket and calls `location.reload()` on message.

## Test plan

- Run `node server.js` — should log "Live reload active on port 3001"
- Open `http://localhost:3000` in browser
- Edit any JS file — browser should auto-reload within ~200ms
- Edit `index.html` — browser should auto-reload
- Verify game WebSocket (multiplayer) still works on port 3000

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)