### PR TITLE
feat: reverse track mode

### DIFF
--- a/js/Settings.js
+++ b/js/Settings.js
@@ -17,6 +17,7 @@ const DEFAULTS = {
 	vehicleColor: '',
 	characterColor: '',
 	ghostEnabled: true,
+	reverseTrack: false,
 };
 
 export class Settings {

--- a/js/TrackIntel.js
+++ b/js/TrackIntel.js
@@ -526,6 +526,40 @@ export class TrackIntel {
 
 	}
 
+	// ─── Reverse Mode ───────────────────────────────────────
+
+	/**
+	 * Reverse the waypoint order so the track is raced in the opposite direction.
+	 * Recomputes cumulative distances. Waypoint 0 stays as the finish/start position
+	 * but the traversal direction is flipped.
+	 */
+	reverse() {
+
+		if ( ! this.valid || this.count < 2 ) return;
+
+		this.waypoints.reverse();
+		this._orderedCells.reverse();
+
+		// Recompute cumulative distances
+		this._cumDist[ 0 ] = 0;
+		for ( let i = 1; i < this.count; i ++ ) {
+
+			const prev = this.waypoints[ i - 1 ];
+			const curr = this.waypoints[ i ];
+			const dx = curr.x - prev.x;
+			const dz = curr.z - prev.z;
+			this._cumDist[ i ] = this._cumDist[ i - 1 ] + Math.sqrt( dx * dx + dz * dz );
+
+		}
+
+		const last = this.waypoints[ this.count - 1 ];
+		const first = this.waypoints[ 0 ];
+		const closeDx = first.x - last.x;
+		const closeDz = first.z - last.z;
+		this.totalLength = this._cumDist[ this.count - 1 ] + Math.sqrt( closeDx * closeDx + closeDz * closeDz );
+
+	}
+
 	// ─── Internal Helpers ────────────────────────────────────
 
 	_setInvalid( reason ) {

--- a/js/main.js
+++ b/js/main.js
@@ -318,7 +318,8 @@ async function init() {
 	} );
 
 	const spawnPosition = spawn.position;
-	const spawnAngle = spawn.angle;
+	const isReverse = settings.get( 'reverseTrack' ) === true;
+	const spawnAngle = isReverse ? spawn.angle + Math.PI : spawn.angle;
 
 	const playerManager = new PlayerManager( scene, world, models, spawnPosition, spawnAngle );
 
@@ -408,7 +409,8 @@ async function init() {
 	} );
 
 	// Init finish line from spawn/finish cell position (use finishAngle, not spawn angle)
-	raceMode.initFinishLine( spawn.position, spawn.finishAngle );
+	const finishAngle = isReverse ? spawn.finishAngle + Math.PI : spawn.finishAngle;
+	raceMode.initFinishLine( spawn.position, finishAngle );
 
 	// ── Race lobby (zone-based start) ───────────────────────────────────────
 	const raceLobby = new RaceLobby( {
@@ -448,7 +450,9 @@ async function init() {
 	const intelCells = customCells ? deriveRampCells( activeCells ) : activeCells;
 	const trackIntel = new TrackIntel( intelCells );
 
-	console.log( `[TrackIntel] valid=${trackIntel.valid}, cells=${intelCells.length}, customCells=${!!customCells}`, trackIntel.valid ? '' : trackIntel.error );
+	if ( isReverse && trackIntel.valid ) trackIntel.reverse();
+
+	console.log( `[TrackIntel] valid=${trackIntel.valid}, cells=${intelCells.length}, customCells=${!!customCells}, reverse=${isReverse}`, trackIntel.valid ? '' : trackIntel.error );
 
 	if ( ! trackIntel.valid ) {
 
@@ -459,7 +463,7 @@ async function init() {
 	raceMode.trackIntel = trackIntel.valid ? trackIntel : null;
 	vehicle.setTrackIntel( trackIntel.valid ? trackIntel : null );
 
-	const aiManager = new AIManager( scene, world, models, trackIntel.valid ? trackIntel : null, spawnPosition, spawnAngle, spawn.finishAngle );
+	const aiManager = new AIManager( scene, world, models, trackIntel.valid ? trackIntel : null, spawnPosition, spawnAngle, finishAngle );
 	aiManager.totalLaps = 3;
 
 	const minimap = new Minimap( activeCells, bounds );
@@ -683,6 +687,25 @@ async function init() {
 		ghostPlayer.restart();
 
 	};
+
+	// Reverse track toggle in hamburger menu
+	{
+
+		const raceSec = settingsMenu._section( 'Race' );
+		raceSec.appendChild( settingsMenu._toggleRowCustom(
+			'Reverse Track',
+			settings.get( 'reverseTrack' ) === true,
+			( v ) => {
+
+				settings.set( 'reverseTrack', v );
+				// Requires page reload to take effect
+				location.reload();
+
+			}
+		) );
+		settingsMenu.addSection( raceSec );
+
+	}
 
 	// Ghost toggle in hamburger menu
 	{


### PR DESCRIPTION
## Summary

- Adds a "Reverse Track" toggle in the hamburger menu's Race section
- Flips the racing direction by reversing TrackIntel waypoints, rotating the finish line normal 180°, and flipping the spawn angle
- AI pathfinding, position ranking, respawn checkpoints, and wrong-way detection all adapt automatically since they follow the waypoint chain
- Toggle persists in localStorage and requires page reload to take effect

## How it works

At initialization time, if \`reverseTrack\` is enabled:
1. \`spawnAngle\` and \`finishAngle\` are rotated by π (180°) so vehicles face the opposite direction and the finish line counts crossings from the reverse side
2. \`TrackIntel.reverse()\` reverses the waypoint array and recomputes cumulative distances, so the track is traversed in opposite order
3. All downstream systems (AI, position ranking, item boxes, respawn) receive the reversed data transparently

## Test plan

- Enable "Reverse Track" in settings — page should reload
- Race the track — vehicle should face opposite direction at start
- AI should follow the reversed waypoint path
- Laps should count correctly when crossing the finish line in the new direction
- Wrong-way detection should work (going the old forward direction should trigger warning)
- Disable the toggle — track should return to normal direction

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)