### PR TITLE
fix: auto-pause race when browser tab loses focus

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -854,6 +854,21 @@ async function init() {
 	const draftingSystem = new DraftingSystem();
 	const draftLines = new DraftLines( scene );
 
+	// Auto-pause when tab loses focus to protect race timer accuracy
+	document.addEventListener( 'visibilitychange', () => {
+
+		if ( document.hidden ) {
+
+			gamePaused = true;
+
+		} else {
+
+			gamePaused = false;
+
+		}
+
+	} );
+
 	document.addEventListener( 'keydown', ( e ) => {
 
 		if ( e.code === 'KeyP' ) {


### PR DESCRIPTION
Freezes the game loop when the player switches browser tabs, protecting race timer accuracy and personal bests from wall-clock drift. Currently `dt` is clamped to 1/30s but `_elapsedTime` in RaceMode still accumulates the real wall-clock gap, ruining lap times on tab return.

Unpauses automatically when the tab regains focus.

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)