### PR TITLE
feat: lap time delta flash on HUD

### DIFF
--- a/js/HUD.js
+++ b/js/HUD.js
@@ -50,8 +50,21 @@ export class HUD {
 
 		this._lapLine = document.createElement( 'div' );
 		this._timeLine = document.createElement( 'div' );
+
+		// Lap delta flash element (shows +/- time vs best lap)
+		this._lapDeltaEl = document.createElement( 'div' );
+		this._lapDeltaEl.style.cssText = [
+			'font-size:28px', 'font-weight:bold', 'text-align:center',
+			'opacity:0', 'transition:opacity 0.3s',
+			'position:absolute', 'top:100%', 'left:50%', 'transform:translateX(-50%)',
+			'text-shadow:0 2px 4px rgba(0,0,0,0.8)', 'pointer-events:none',
+			'white-space:nowrap',
+		].join( ';' );
+		this._lapDeltaTimeout = null;
+
 		this._raceHud.appendChild( this._lapLine );
 		this._raceHud.appendChild( this._timeLine );
+		this._raceHud.appendChild( this._lapDeltaEl );
 		document.body.appendChild( this._raceHud );
 
 		// ── Results overlay (centered panel) ─────────────────────────────────
@@ -400,6 +413,28 @@ export class HUD {
 			this._powerupEl.style.display = 'none';
 
 		}
+
+	}
+
+	/**
+	 * Show a lap time delta flash (e.g., "+0.42s" or "-0.31s").
+	 * @param {number} delta — seconds difference (positive = slower, negative = faster)
+	 */
+	showLapDelta( delta ) {
+
+		if ( this._lapDeltaTimeout ) clearTimeout( this._lapDeltaTimeout );
+
+		const sign = delta >= 0 ? '+' : '';
+		this._lapDeltaEl.textContent = `${ sign }${ delta.toFixed( 2 ) }s`;
+		this._lapDeltaEl.style.color = delta <= 0 ? '#4f4' : '#f44';
+		this._lapDeltaEl.style.opacity = '1';
+
+		this._lapDeltaTimeout = setTimeout( () => {
+
+			this._lapDeltaEl.style.opacity = '0';
+			this._lapDeltaTimeout = null;
+
+		}, 2000 );
 
 	}
 

--- a/js/main.js
+++ b/js/main.js
@@ -660,7 +660,8 @@ async function init() {
 
 	}
 
-	// Wrap existing onLapComplete to add ghost recording
+	// Wrap existing onLapComplete to add ghost recording + delta flash
+	let prevBestLap = Infinity;
 	const _prevOnLapComplete = raceMode.onLapComplete;
 	raceMode.onLapComplete = ( lap, time ) => {
 
@@ -681,6 +682,15 @@ async function init() {
 		}
 
 		ghostPlayer.restart();
+
+		// Show lap delta flash (compare to previous best lap)
+		if ( prevBestLap < Infinity ) {
+
+			hud.showLapDelta( time - prevBestLap );
+
+		}
+
+		if ( time < prevBestLap ) prevBestLap = time;
 
 	};
 


### PR DESCRIPTION
Shows a green/red time delta when completing a lap (e.g., "-0.31s" in green for faster, "+0.42s" in red for slower). Compares each lap against the previous best lap from the current race. Fades out after 2 seconds.

First lap shows no delta (no baseline). Subsequent laps flash the comparison, giving immediate feedback on improvement without waiting for the results screen.

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)