### PR TITLE
fix: reject backward/shortcut lap crossings

### DIFF
--- a/js/RaceMode.js
+++ b/js/RaceMode.js
@@ -52,6 +52,7 @@ export class RaceMode extends GameMode {
 
 		this._finishLine = null;
 		this._prevPos = null;
+		this._maxProgressThisLap = 0;
 
 		this._displayState = {};
 
@@ -241,6 +242,7 @@ export class RaceMode extends GameMode {
 		this._bestLap = Infinity;
 		this._totalTime = 0;
 		this._prevPos = null;
+		this._maxProgressThisLap = 0;
 		this._lastSegmentHint = null;
 		this._position = 1;
 
@@ -334,7 +336,25 @@ export class RaceMode extends GameMode {
 		const result = this._finishLine.check( this._prevPos, currPos );
 		this._prevPos.copy( currPos );
 
+		// Track max progress for lap validation
+		if ( this.trackIntel && this._state === STATE_RACING ) {
+
+			const p = this.trackIntel.getProgress( currPos.x, currPos.z );
+			if ( p > this._maxProgressThisLap ) this._maxProgressThisLap = p;
+
+		}
+
 		if ( result.crossed && result.direction === 'forward' ) {
+
+			// Reject shortcut laps: must have reached 75%+ track progress
+			if ( this.trackIntel && this._lap > 0 && this._maxProgressThisLap < 0.75 ) {
+
+				this._maxProgressThisLap = 0;
+				return;
+
+			}
+
+			this._maxProgressThisLap = 0;
 
 			this._lap ++;
 


### PR DESCRIPTION
Tracks the maximum track progress reached during each lap. When a finish-line forward crossing is detected, the lap is only counted if the player reached at least 75% progress on the track. This prevents an exploit where driving backward through the finish line then forward a short distance registers a fake lap with an illegitimate time.

The first lap (lap 0 -> 1) is exempt since the player starts at the finish line. Ghost recordings and race stats are also protected since they only record after a valid lap completion.

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)