### PR TITLE
feat: engine pitch gear-shift curve

### DIFF
--- a/js/Audio.js
+++ b/js/Audio.js
@@ -1,5 +1,33 @@
 import * as THREE from 'three';
 
+/**
+ * Stepped pitch curve simulating gear shifts.
+ * Each gear ramps pitch up, then drops on the "shift" to the next gear.
+ */
+const GEARS = [
+	{ from: 0.00, to: 0.30, pitchLow: 0.25, pitchHigh: 1.2 },  // 1st gear
+	{ from: 0.30, to: 0.60, pitchLow: 0.8,  pitchHigh: 1.8 },  // 2nd gear
+	{ from: 0.60, to: 0.85, pitchLow: 1.3,  pitchHigh: 2.4 },  // 3rd gear
+	{ from: 0.85, to: 1.00, pitchLow: 1.8,  pitchHigh: 3.0 },  // 4th gear
+];
+
+function gearShiftPitch( speedFactor ) {
+
+	for ( const g of GEARS ) {
+
+		if ( speedFactor <= g.to ) {
+
+			const t = ( speedFactor - g.from ) / ( g.to - g.from );
+			return g.pitchLow + t * ( g.pitchHigh - g.pitchLow );
+
+		}
+
+	}
+
+	return 3.0;
+
+}
+
 function remap( value, inMin, inMax, outMin, outMax ) {
 
 	return outMin + ( outMax - outMin ) * ( ( value - inMin ) / ( inMax - inMin ) );
@@ -217,7 +245,7 @@ export class GameAudio {
 		const currentVol = this.engineSound.getVolume();
 		this.engineSound.setVolume( THREE.MathUtils.lerp( currentVol, targetVol, dt * 5 ) );
 
-		let targetPitch = remap( speedFactor, 0, 1, 0.25, 3 );
+		let targetPitch = gearShiftPitch( speedFactor );
 		if ( throttleFactor > 0.1 ) targetPitch += 0.2;
 		const currentPitch = this.engineSound.getPlaybackRate();
 		this.engineSound.setPlaybackRate( THREE.MathUtils.lerp( currentPitch, targetPitch, dt * 2 ) );


### PR DESCRIPTION
Replaces the linear engine pitch ramp (0.25 → 3.0) with a 4-gear stepped curve that simulates gear shifts. Each gear ramps pitch up within its speed range, then drops to the next gear's base pitch at the shift point.

| Gear | Speed Range | Pitch Range |
|------|-------------|-------------|
| 1st  | 0-30%       | 0.25 → 1.2 |
| 2nd  | 30-60%      | 0.8 → 1.8  |
| 3rd  | 60-85%      | 1.3 → 2.4  |
| 4th  | 85-100%     | 1.8 → 3.0  |

No new audio assets needed — purely modifies the playback rate mapping.

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)