### PR TITLE
feat: engine rev during countdown when gas is held

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1160,7 +1160,9 @@ async function init() {
 
 		}
 
-		audio.update( dt, vehicle ? vehicle.linearSpeed : 0, input.z, vehicle ? vehicle.driftIntensity : 0 );
+		// During countdown, use raw gas input for engine rev effect even though vehicle isn't moving
+		const audioThrottle = raceMode.state === 'countdown' ? rawInput.z : input.z;
+		audio.update( dt, vehicle ? vehicle.linearSpeed : 0, audioThrottle, vehicle ? vehicle.driftIntensity : 0 );
 
 		// Draft wind audio — get player's draft intensity
 		if ( vehicle ) {


### PR DESCRIPTION
Passes raw throttle input to the audio system during the 3-2-1 countdown so holding gas produces an escalating engine rev sound. Previously the countdown zeroed all input including audio throttle, making the pre-race period feel dead.

3-line change — uses \`rawInput.z\` instead of \`input.z\` (filtered to zero) for audio during countdown state.

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)