### PR TITLE
feat: brake lights on vehicles

### DIFF
--- a/js/Vehicle.js
+++ b/js/Vehicle.js
@@ -336,6 +336,13 @@ export class Vehicle {
 			this.wheelBR ? this.wheelBR.position.y : 0,
 		];
 
+		// ─── Brake light ─────────────────────────────────────────────────────
+		this.brakeLight = new THREE.PointLight( 0xff2200, 2, 3 );
+		this.brakeLight.position.set( 0, 0.2, - 0.6 );
+		this.brakeLight.castShadow = false;
+		this.brakeLight.visible = false;
+		this.container.add( this.brakeLight );
+
 		// ─── Underglow ────────────────────────────────────────────────────────
 		this.underglowLight = new THREE.PointLight( 0x00ffff, 1, 3 );
 		this.underglowLight.position.set( 0, - 0.1, 0 );
@@ -585,6 +592,13 @@ export class Vehicle {
 
 		this.inputX = controlsInput.x;
 		this.inputZ = controlsInput.z;
+
+		// Brake light — visible when braking at speed
+		if ( this.brakeLight ) {
+
+			this.brakeLight.visible = this.inputZ < - 0.1 && this.linearSpeed > 0.5;
+
+		}
 
 		// Tick health timers (invuln, consecutive hit cooldown)
 		if ( this.health ) this.health.update( dt );


### PR DESCRIPTION
Adds a red PointLight at the rear of each vehicle that activates when braking at speed. Provides a visual telegraph when following another kart — a universal racing-game readability cue that was missing.

Light activates when \`inputZ < -0.1\` (brake held) and \`linearSpeed > 0.5\` (moving fast enough for braking to matter). Works for both player and AI vehicles since AI sets the same input values.

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)