### PR TITLE
feat: AI racer personality nameplates above vehicles

### DIFF
--- a/js/AIManager.js
+++ b/js/AIManager.js
@@ -8,6 +8,7 @@ import { TireMarks } from './TireMarks.js';
 import { FinishLine } from './FinishLine.js';
 import { AIController } from './AIController.js';
 import { AI_PROFILES } from './AIProfiles.js';
+import { AINameplate } from './AINameplate.js';
 import { ItemSlotManager } from './ItemSlotManager.js';
 import { rigidBody } from 'crashcat';
 
@@ -60,6 +61,7 @@ export class AIManager {
 		this._activeVehiclesCache = [];
 		this._raceDataCache = [];
 		this._aiColors = generateAIColors( 8 );
+		this._camera = null;
 
 	}
 
@@ -136,6 +138,9 @@ export class AIManager {
 		vehicle.itemSlot = new ItemSlotManager( vehicle );
 		const controller = new AIController( this.trackIntel, index, profile );
 
+		const nameplate = new AINameplate( profile.name, aiColor );
+		this.scene.add( nameplate.sprite );
+
 		const finishLine = new FinishLine( {
 			position: this.spawnPosition,
 			angle: this.finishAngle
@@ -146,6 +151,7 @@ export class AIManager {
 			vehicle,
 			controller,
 			profile,
+			nameplate,
 			smokeTrails: new SmokeTrails( this.scene ),
 			driftSparks: new DriftSparks( this.scene ),
 			boostFlame: new BoostFlame( this.scene ),
@@ -166,6 +172,13 @@ export class AIManager {
 
 		removeVehicleBody( this.world, ai.vehicle.rigidBody );
 		this.scene.remove( ai.vehicle.container );
+
+		if ( ai.nameplate ) {
+
+			this.scene.remove( ai.nameplate.sprite );
+			ai.nameplate.dispose();
+
+		}
 
 		ai.smokeTrails.dispose();
 		ai.driftSparks.dispose();
@@ -213,6 +226,13 @@ export class AIManager {
 			ai.driftSparks.update( dt, ai.vehicle );
 			ai.boostFlame.update( dt, ai.vehicle );
 			ai.tireMarks.update( dt, ai.vehicle );
+
+			// Nameplate
+			if ( ai.nameplate && this._camera ) {
+
+				ai.nameplate.update( ai.vehicle.container, this._camera );
+
+			}
 
 			// Finish line check during racing
 			if ( raceState === 'racing' ) {

--- a/js/AINameplate.js
+++ b/js/AINameplate.js
@@ -1,0 +1,92 @@
+import * as THREE from 'three';
+
+const LABEL_HEIGHT = 2.8;
+const FADE_NEAR = 8;
+const FADE_FAR = 40;
+
+function createLabelTexture( text, color ) {
+
+	const canvas = document.createElement( 'canvas' );
+	canvas.width = 256;
+	canvas.height = 64;
+	const ctx = canvas.getContext( '2d' );
+
+	ctx.font = 'bold 28px sans-serif';
+	ctx.textAlign = 'center';
+	ctx.textBaseline = 'middle';
+
+	// Background pill
+	const metrics = ctx.measureText( text );
+	const pw = metrics.width + 24;
+	const ph = 36;
+	const px = ( canvas.width - pw ) / 2;
+	const py = ( canvas.height - ph ) / 2;
+	ctx.fillStyle = 'rgba(0,0,0,0.45)';
+	ctx.beginPath();
+	ctx.roundRect( px, py, pw, ph, 12 );
+	ctx.fill();
+
+	// Text with vehicle color tint
+	const r = Math.round( color.r * 255 );
+	const g = Math.round( color.g * 255 );
+	const b = Math.round( color.b * 255 );
+	ctx.fillStyle = `rgb(${r},${g},${b})`;
+	ctx.fillText( text, canvas.width / 2, canvas.height / 2 );
+
+	const texture = new THREE.CanvasTexture( canvas );
+	texture.minFilter = THREE.LinearFilter;
+	return texture;
+
+}
+
+export class AINameplate {
+
+	constructor( text, color ) {
+
+		const texture = createLabelTexture( text, color );
+		const material = new THREE.SpriteMaterial( {
+			map: texture,
+			transparent: true,
+			depthTest: false,
+			sizeAttenuation: true,
+		} );
+
+		this.sprite = new THREE.Sprite( material );
+		this.sprite.scale.set( 2.0, 0.5, 1 );
+		this.sprite.renderOrder = 999;
+		this._texture = texture;
+
+	}
+
+	update( vehicleContainer, camera ) {
+
+		const pos = vehicleContainer.position;
+		this.sprite.position.set( pos.x, pos.y + LABEL_HEIGHT, pos.z );
+
+		// Fade based on distance to camera
+		const dist = camera.position.distanceTo( this.sprite.position );
+		if ( dist < FADE_NEAR ) {
+
+			this.sprite.material.opacity = 0;
+
+		} else if ( dist > FADE_FAR ) {
+
+			this.sprite.material.opacity = 0;
+
+		} else {
+
+			const t = ( dist - FADE_NEAR ) / ( FADE_FAR - FADE_NEAR );
+			this.sprite.material.opacity = t < 0.2 ? t / 0.2 : ( t > 0.8 ? ( 1 - t ) / 0.2 : 1 );
+
+		}
+
+	}
+
+	dispose() {
+
+		this._texture.dispose();
+		this.sprite.material.dispose();
+
+	}
+
+}

--- a/js/main.js
+++ b/js/main.js
@@ -587,6 +587,8 @@ async function init() {
 		fpsCapMs, draftIndicatorEnabled,
 	} ) );
 
+	aiManager._camera = cam.camera;
+
 	// Auto-enable top-down debug mode via ?debug=topdown
 	if ( debugTopdown ) {
 


### PR DESCRIPTION
Floating name labels above each AI kart display their personality type (Aggressive, Cautious, Drifter, Strategist) using the vehicle's tint color. Labels use canvas-textured sprites with distance-based fade — visible at mid-range, hidden when too close or too far to avoid HUD clutter.

## Test plan
- [ ] Start a race with AI opponents and verify name labels appear above each AI kart
- [ ] Drive close to an AI — label should fade out within ~8 units
- [ ] Drive far from an AI — label should fade out beyond ~40 units
- [ ] Verify each AI's label matches its profile name and color tint
- [ ] Reduce AI count mid-race — verify nameplates are properly cleaned up

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)