### PR TITLE
feat: add top-down camera to the mode cycle

### DIFF
--- a/js/Camera.js
+++ b/js/Camera.js
@@ -65,6 +65,9 @@ export class Camera {
 		this.dashboardOffset = new THREE.Vector3( 0.0, 0.40, -0.05 );
 		this.dashboardFOV = 80;
 
+		// Top-down camera
+		this._topdownHeight = 50;
+
 		// Look-behind (hold Backspace)
 		this.lookBehind = false;
 
@@ -539,7 +542,9 @@ export class Camera {
 		if ( this.mode === 'chase' ) this.mode = 'cockpit';
 		else if ( this.mode === 'cockpit' ) this.mode = 'dashboard';
 		else if ( this.mode === 'dashboard' ) this.mode = 'isometric';
-		else if ( this.mode === 'isometric' ) this.mode = 'chase';
+		else if ( this.mode === 'isometric' ) this.mode = 'topdown';
+		else if ( this.mode === 'topdown' ) this.mode = 'chase';
+		else this.mode = 'chase';
 
 	}
 


### PR DESCRIPTION
Adds the existing top-down overhead view as a playable camera mode in the C-key cycle: chase → cockpit → dashboard → isometric → top-down → chase. Previously this view was only accessible through the debug panel. Initializes the top-down height at 50 units (zoomable with scroll wheel).

## Test plan
- [ ] Press C repeatedly — verify top-down appears after isometric and cycles back to chase
- [ ] In top-down mode, verify the camera looks straight down and follows the vehicle
- [ ] Scroll wheel zooms in/out in top-down mode
- [ ] Race is fully playable in top-down view

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)