### PR TITLE
perf: event-driven gamepad caching in Haptics

### DIFF
--- a/js/Haptics.js
+++ b/js/Haptics.js
@@ -6,40 +6,59 @@ export class Haptics {
 		this._rumbleTimer = 0;
 		this._rumbleInterval = 0.1; // re-trigger every 100ms
 
-	}
+		this._onConnected = ( e ) => {
 
-	update( dt ) {
+			if ( e.gamepad.vibrationActuator ) {
 
-		// Poll for gamepad with vibration support
-		const gamepads = navigator.getGamepads();
-
-		this._gamepad = null;
-
-		for ( const gp of gamepads ) {
-
-			if ( gp && gp.vibrationActuator ) {
-
-				this._gamepad = gp;
-				break;
+				this._gamepad = e.gamepad;
 
 			}
 
-		}
+		};
+
+		this._onDisconnected = ( e ) => {
+
+			if ( this._gamepad && this._gamepad.index === e.gamepad.index ) {
+
+				this._gamepad = null;
+
+			}
+
+		};
+
+		window.addEventListener( 'gamepadconnected', this._onConnected );
+		window.addEventListener( 'gamepaddisconnected', this._onDisconnected );
+
+	}
+
+	update( dt ) {
 
 		if ( this._rumbleTimer > 0 ) this._rumbleTimer -= dt;
 
 	}
 
+	_getGamepad() {
+
+		// Cached gamepad references go stale each frame in some browsers;
+		// re-resolve from the index when a vibration call needs it
+		if ( this._gamepad === null ) return null;
+
+		const fresh = navigator.getGamepads()[ this._gamepad.index ];
+		return ( fresh && fresh.vibrationActuator ) ? fresh : null;
+
+	}
+
 	setRumble( intensity ) {
 
-		if ( ! this._gamepad || this._rumbleTimer > 0 ) return;
+		const gp = this._getGamepad();
+		if ( ! gp || this._rumbleTimer > 0 ) return;
 
 		const strong = Math.min( intensity * 0.3, 1 );
 		const weak = Math.min( intensity * 0.5, 1 );
 
 		try {
 
-			this._gamepad.vibrationActuator.playEffect( 'dual-rumble', {
+			gp.vibrationActuator.playEffect( 'dual-rumble', {
 				duration: 150,
 				strongMagnitude: strong,
 				weakMagnitude: weak,
@@ -53,13 +72,14 @@ export class Haptics {
 
 	impulse( intensity ) {
 
-		if ( ! this._gamepad ) return;
+		const gp = this._getGamepad();
+		if ( ! gp ) return;
 
 		const strong = Math.min( intensity * 0.15, 1 );
 
 		try {
 
-			this._gamepad.vibrationActuator.playEffect( 'dual-rumble', {
+			gp.vibrationActuator.playEffect( 'dual-rumble', {
 				duration: 100,
 				strongMagnitude: strong,
 				weakMagnitude: 0,
@@ -71,11 +91,12 @@ export class Haptics {
 
 	pulse() {
 
-		if ( ! this._gamepad ) return;
+		const gp = this._getGamepad();
+		if ( ! gp ) return;
 
 		try {
 
-			this._gamepad.vibrationActuator.playEffect( 'dual-rumble', {
+			gp.vibrationActuator.playEffect( 'dual-rumble', {
 				duration: 80,
 				strongMagnitude: 0,
 				weakMagnitude: 0.3,


### PR DESCRIPTION
Replaces per-frame navigator.getGamepads() polling with event-driven caching. The gamepad is captured on the gamepadconnected event and cleared on disconnect. When a vibration effect fires, the cached index is re-resolved to handle the Gamepad API's snapshot semantics. The update() loop no longer touches the Gamepad API at all.

Addresses deferred P3-11 from tasks/todo.md.

## Test plan
- [ ] Connect a gamepad — verify rumble/impulse/pulse effects still work
- [ ] Disconnect gamepad mid-race — verify no errors
- [ ] Reconnect — verify haptics resume
- [ ] Race without a gamepad — verify no performance regression

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)