### PR TITLE
feat: per-track physics profiles via URL param

### DIFF
--- a/js/PhysicsProfiles.js
+++ b/js/PhysicsProfiles.js
@@ -1,0 +1,72 @@
+// PhysicsProfiles.js — per-track physics parameter overrides
+//
+// Each profile is a set of multipliers applied to Vehicle.debug defaults.
+// Values are multipliers: 1.0 = no change, 0.5 = halved, 2.0 = doubled.
+
+export const PHYSICS_PROFILES = {
+
+	arcade: {
+		name: 'Arcade',
+		description: 'Default handling',
+	},
+
+	ice: {
+		name: 'Ice',
+		description: 'Low grip, extreme sliding',
+		topSpeed: 0.85,
+		accelerationRate: 0.7,
+		steeringMultiplier: 0.5,
+		steeringGripMin: 0.05,
+		steeringGripMax: 0.4,
+		linearDamp: 0.03,
+		brakeRate: 0.4,
+		driftThreshold: 0.3,
+	},
+
+	moon: {
+		name: 'Moon',
+		description: 'Low gravity, floaty jumps',
+		topSpeed: 0.75,
+		accelerationRate: 0.6,
+		linearDamp: 0.04,
+		steeringMultiplier: 0.8,
+	},
+
+	turbo: {
+		name: 'Turbo',
+		description: 'High speed, twitchy controls',
+		topSpeed: 1.5,
+		accelerationRate: 1.8,
+		steeringMultiplier: 1.3,
+		brakeRate: 1.5,
+		boostTopSpeed: 1.3,
+	},
+
+};
+
+export const DEFAULT_PROFILE = 'arcade';
+
+/**
+ * Apply a physics profile to a vehicle's debug parameters.
+ * Multipliers are applied to the vehicle's current values.
+ * @param {object} vehicle - Vehicle instance
+ * @param {string} profileName - Key from PHYSICS_PROFILES
+ */
+export function applyPhysicsProfile( vehicle, profileName ) {
+
+	const profile = PHYSICS_PROFILES[ profileName ];
+	if ( ! profile || profileName === 'arcade' ) return;
+
+	const d = vehicle.debug;
+
+	if ( profile.topSpeed ) d.topSpeed *= profile.topSpeed;
+	if ( profile.accelerationRate ) d.accelerationRate *= profile.accelerationRate;
+	if ( profile.steeringMultiplier ) d.steeringMultiplier *= profile.steeringMultiplier;
+	if ( profile.steeringGripMin ) d.steeringGripMin = profile.steeringGripMin;
+	if ( profile.steeringGripMax ) d.steeringGripMax = profile.steeringGripMax;
+	if ( profile.linearDamp ) d.linearDamp = profile.linearDamp;
+	if ( profile.brakeRate ) d.brakeRate *= profile.brakeRate;
+	if ( profile.driftThreshold ) d.driftThreshold = profile.driftThreshold;
+	if ( profile.boostTopSpeed ) d.boostTopSpeed *= profile.boostTopSpeed;
+
+}

--- a/js/main.js
+++ b/js/main.js
@@ -48,6 +48,7 @@ import { RearviewMirror } from './RearviewMirror.js';
 import { GhostRecorder } from './GhostRecorder.js';
 import { GhostPlayer } from './GhostPlayer.js';
 import { getTrackId } from './GhostStorage.js';
+import { applyPhysicsProfile, PHYSICS_PROFILES } from './PhysicsProfiles.js';
 
 
 const SPECTATE_INPUT = { x: 0, z: 0, touchActive: false, boost: false, gas: false, brake: false };
@@ -199,6 +200,7 @@ async function init() {
 	const mapParam = urlParams.get( 'map' )
 		|| new URLSearchParams( window.location.hash.slice( 1 ) ).get( 'map' );
 	const debugTopdown = urlParams.get( 'debug' ) === 'topdown';
+	const physicsProfile = urlParams.get( 'physics' ) || 'arcade';
 	let customCells = null;
 
 	if ( mapParam ) {
@@ -387,6 +389,13 @@ async function init() {
 	// Direct reference for debug panel compatibility
 	const vehicle = playerManager.localVehicle;
 
+	// Apply physics profile from URL param (?physics=ice|moon|turbo)
+	if ( physicsProfile !== 'arcade' && PHYSICS_PROFILES[ physicsProfile ] ) {
+
+		applyPhysicsProfile( vehicle, physicsProfile );
+		console.log( `[physics] Applied profile: ${ PHYSICS_PROFILES[ physicsProfile ].name }` );
+
+	}
 
 	const dirLightOffset = { x: 11.4, y: 15, z: - 5.3 };
 	let lastShadowX = 0, lastShadowZ = 0;


### PR DESCRIPTION
Adds swappable physics profiles that modify vehicle handling per-track. Profiles are multiplier-based, applied to Vehicle.debug constants at race start.

**Available profiles:** \`?physics=arcade\` (default), \`?physics=ice\` (low grip, extreme sliding), \`?physics=moon\` (low gravity feel), \`?physics=turbo\` (high speed, twitchy)

Each profile adjusts top speed, acceleration, steering, grip, damping, and braking multipliers. The arcade profile is a no-op (identity). Future: editor can embed the profile name in track metadata.

## Test plan
- [ ] Load \`?physics=ice\` — verify reduced grip and extreme sliding
- [ ] Load \`?physics=moon\` — verify floaty, slow acceleration
- [ ] Load \`?physics=turbo\` — verify faster top speed and twitchy steering
- [ ] Load with no param — verify default arcade handling unchanged
- [ ] Load with invalid param (\`?physics=banana\`) — verify default handling

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)