### PR TITLE
chore: remove window.isMobile global

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -53,7 +53,6 @@ import { getTrackId } from './GhostStorage.js';
 const SPECTATE_INPUT = { x: 0, z: 0, touchActive: false, boost: false, gas: false, brake: false };
 
 const isMobile = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
-window.isMobile = isMobile;
 
 let renderer;
 let bloomPass;
@@ -1003,7 +1002,7 @@ async function init() {
 
 				if ( vehicle.underglowLight ) {
 
-					if ( ! window.isMobile ) vehicle.underglowLight.visible = true;
+					if ( ! isMobile ) vehicle.underglowLight.visible = true;
 					vehicle.underglowLight.color.setHex( 0xff8800 );
 
 				}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -15,5 +15,5 @@
 - [ ] P1-3: Triangle mesh colliders built from visual meshes — if models gain LODs or decorative geometry, phantom collisions will appear. Consider separate collision meshes or filtering by mesh name convention.
 - [ ] P2-8: Single player can start race alone via RaceLobby (`zoneCount >= 1`). Decide if this is intentional or if solo should go through countdown differently.
 - [ ] P3-10: `window.isMobile` global — pass through constructor/config instead of polluting global scope.
-- [ ] P3-11: `Haptics.js` polls `navigator.getGamepads()` every frame — cache on `gamepadconnected` event instead.
+- [x] P3-11: `Haptics.js` polls `navigator.getGamepads()` every frame — cache on `gamepadconnected` event instead. (PR #130)
 - [ ] P3-12: `Audio.js` boost whoosh bypasses Three.js spatial audio — connects directly to `ctx.destination`. Fine for local player, wrong if ever used for remote players.


### PR DESCRIPTION
Removes the \`window.isMobile\` global scope pollution. The mobile detection was already a module-level const in main.js — the only consumer was also in main.js. Addresses deferred P3-10 from tasks/todo.md.

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)