### PR TITLE
perf: use Map for PostProcessing effect lookup

### DIFF
--- a/js/PostProcessing.js
+++ b/js/PostProcessing.js
@@ -278,6 +278,8 @@ export class PostProcessing {
 			{ name: 'screenShake',         pass: screenShakePass,  enabled: false },
 		];
 
+		this._effectMap = new Map( this.effects.map( e => [ e.name, e ] ) );
+
 		this.rebuildEffects();
 
 	}
@@ -341,7 +343,7 @@ export class PostProcessing {
 	/** Return the full effect entry { name, pass, enabled }. */
 	getEffect( name ) {
 
-		return this.effects.find( e => e.name === name ) ?? null;
+		return this._effectMap.get( name ) ?? null;
 
 	}
 


### PR DESCRIPTION
Replaces per-frame \`Array.find()\` with \`Map.get()\` for the \`getEffect()\` method in PostProcessing. Called 9+ times per frame during the update loop (motionBlur, radialZoom, screenShake, godRays lookups). The Map is built once from the effects array in the constructor.

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)