### PR TITLE
chore: remove unused export from resolveQuadrantFromLocal

### DIFF
--- a/js/DamageRouter.js
+++ b/js/DamageRouter.js
@@ -52,7 +52,7 @@ export function resolveQuadrant( attackerPos, defenderVehicle ) {
  * @param {THREE.Vector3} localDir - normalized direction in vehicle local space
  * @returns {number} QUADRANT enum value
  */
-export function resolveQuadrantFromLocal( localDir ) {
+function resolveQuadrantFromLocal( localDir ) {
 
 	const isFront = localDir.z > 0;
 	const isLeft = localDir.x < 0;


### PR DESCRIPTION
\`resolveQuadrantFromLocal\` in DamageRouter.js was exported but never imported by any other module. Removing the export to clarify the module's public API surface.

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)