### PR TITLE
refactor: extract duplicate elevToY to ElevationUtils

### DIFF
--- a/js/ElevationUtils.js
+++ b/js/ElevationUtils.js
@@ -1,6 +1,25 @@
 // ─── Elevation Utilities ─────────────────────────────────────────────
-// Shared between editor (Elevation.js) and game (Track.js).
+// Shared between editor (Elevation.js) and game (Track.js, Physics.js).
 // Pure functions — no dependencies on state or THREE.
+
+// Elevation step → world Y offset
+// Editor uses steps 0-24 (12=ground), each step = 2.5m (matches model geometry)
+export const ELEV_GROUND = 12;
+export const ELEV_STEP_Y = 2.5;
+
+export function elevToY( flags ) {
+
+	// Use fullElevation (v4) if available, fall back to legacy v3 elevation
+	if ( flags?.fullElevation != null && flags.fullElevation !== ELEV_GROUND ) {
+
+		return ( flags.fullElevation - ELEV_GROUND ) * ELEV_STEP_Y;
+
+	}
+
+	const elev = flags?.elevation || 0;
+	return elev * ELEV_STEP_Y;
+
+}
 
 /**
  * Get the model name for an elevation piece.

--- a/js/Physics.js
+++ b/js/Physics.js
@@ -2,24 +2,9 @@ import * as THREE from 'three';
 import { rigidBody, box, triangleMesh, MotionType, MotionQuality } from 'crashcat';
 import { TRACK_CELLS, CELL_RAW, ORIENT_DEG } from './Track.js';
 import { getCurveConfig } from './TileMetadata.js';
+import { elevToY } from './ElevationUtils.js';
 
 const _vec3 = new THREE.Vector3();
-
-const ELEV_GROUND = 12;
-const ELEV_STEP_Y = 2.5;
-
-function elevToY( flags ) {
-
-	if ( flags?.fullElevation != null && flags.fullElevation !== ELEV_GROUND ) {
-
-		return ( flags.fullElevation - ELEV_GROUND ) * ELEV_STEP_Y;
-
-	}
-
-	const elev = flags?.elevation || 0;
-	return elev * ELEV_STEP_Y;
-
-}
 
 export function buildTrackColliders( world, models, customCells ) {
 

--- a/js/Track.js
+++ b/js/Track.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { getTrackModelConfig } from './TrackModelConfig.js';
 import { getCurveConfig, getCurveLR } from './TileMetadata.js';
-import { getElevationModelName, scanElevatedRun } from './ElevationUtils.js';
+import { getElevationModelName, scanElevatedRun, elevToY, ELEV_GROUND, ELEV_STEP_Y } from './ElevationUtils.js';
 
 // Re-export from focused modules for backward compatibility
 export { ORIENT_DEG, CELL_RAW, GRID_SCALE } from './TrackConstants.js';
@@ -15,26 +15,6 @@ import { DECO_CELLS } from './TrackData.js';
 const _dummy = new THREE.Object3D();
 const _childMat = new THREE.Matrix4();
 const _combinedMat = new THREE.Matrix4();
-
-// Elevation step → world Y offset
-// Editor uses steps 0-24 (12=ground), each step = 2.5m (matches model geometry)
-// Legacy v3 elevation: 0=ground, 1=2.5m, 2=5.0m
-const ELEV_GROUND = 12;
-const ELEV_STEP_Y = 2.5;
-
-function elevToY( flags ) {
-
-	// Use fullElevation (v4) if available, fall back to legacy v3 elevation
-	if ( flags?.fullElevation != null && flags.fullElevation !== ELEV_GROUND ) {
-
-		return ( flags.fullElevation - ELEV_GROUND ) * ELEV_STEP_Y;
-
-	}
-
-	const elev = flags?.elevation || 0;
-	return elev * ELEV_STEP_Y;
-
-}
 
 
 


### PR DESCRIPTION
`elevToY()`, `ELEV_GROUND`, and `ELEV_STEP_Y` were identically defined in both Track.js and Physics.js. Moves them to `ElevationUtils.js` — which already existed as the shared elevation helper module — eliminating the duplication and preventing silent divergence.

---

🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)