### PR TITLE
fix: clear wrecks on race restart

### DIFF
--- a/js/WreckManager.js
+++ b/js/WreckManager.js
@@ -194,6 +194,17 @@ export class WreckManager {
 
 	}
 
+	reset() {
+
+		// Remove all active wrecks (hide containers, clear smoke)
+		while ( this._wrecks.length > 0 ) {
+
+			this._removeWreck( 0 );
+
+		}
+
+	}
+
 	dispose() {
 
 		for ( const sprite of this._smokePool ) {

--- a/js/main.js
+++ b/js/main.js
@@ -441,7 +441,7 @@ async function init() {
 	} );
 
 	const hud = new HUD(
-		() => { raceMode.reset(); aiManager.resetRace(); raceLobby.reset(); },
+		() => { raceMode.reset(); aiManager.resetRace(); raceLobby.reset(); wreckManager.reset(); },
 		() => raceLobby.setReady( playerManager.localId )
 	);
 


### PR DESCRIPTION
Adds `WreckManager.reset()` and calls it in the race restart callback. Previously, wreck obstacles from eliminated vehicles persisted across restarts (60s despawn timer), acting as invisible hazards at spawn positions when players quickly restarted a race.

---

🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)