### PR TITLE
refactor(play): track selection overlay + race mode flow fixes

### DIFF
--- a/js/ui/overlays/TrackSelectOverlay.js
+++ b/js/ui/overlays/TrackSelectOverlay.js
@@ -1,0 +1,369 @@
+/**
+ * TrackSelectOverlay — full-screen overlay for track selection.
+ *
+ * Opens after pressing PLAY in FREE PLAY or PARTY mode.
+ * Uses the TrackBrowser component for browse/select/minimap.
+ * Has a GO button that fires the onConfirm callback with the selected track.
+ *
+ * Lifecycle:
+ *   constructor(container, services)
+ *   show(onConfirm)   — display overlay, call onConfirm(trackData) when GO is tapped
+ *   hide()            — dismiss overlay
+ *   dispose()         — full cleanup
+ */
+
+import { TrackBrowser }   from '../components/TrackBrowser.js';
+import { HudButton }      from '../components/HudButton.js';
+import { Settings }        from '../../Settings.js';
+import { getTrackById, getTracks } from '../../TrackRegistry.js';
+import { decodeCells }     from '../../TrackCodec.js';
+import { getSavedTracks }  from '../../editor/Persistence.js';
+
+export class TrackSelectOverlay {
+
+	static _cssInjected = false;
+
+	/**
+	 * @param {HTMLElement} container  Shell element to append overlay into.
+	 * @param {object}      services   AppShell service bag.
+	 */
+	constructor( container, services ) {
+
+		/** @type {HTMLElement} */
+		this._container = container;
+
+		/** @type {object} */
+		this._services = services;
+
+		/** @type {TrackBrowser | null} */
+		this._browser = null;
+
+		/** @type {HudButton | null} */
+		this._goBtn = null;
+
+		/** @type {HTMLElement | null} */
+		this._overlay = null;
+
+		/** @type {Function | null} */
+		this._onConfirm = null;
+
+		this._injectCSS();
+
+	}
+
+	// ---------------------------------------------------------------------------
+	// CSS
+	// ---------------------------------------------------------------------------
+
+	_injectCSS() {
+
+		if ( TrackSelectOverlay._cssInjected ) return;
+		TrackSelectOverlay._cssInjected = true;
+
+		const style = document.createElement( 'style' );
+		style.textContent = `
+
+			.kk-track-select {
+				position: fixed;
+				inset: 0;
+				z-index: 45;
+				display: flex;
+				flex-direction: column;
+				background: rgba( 10, 10, 10, 0.92 );
+				backdrop-filter: blur( 12px );
+				-webkit-backdrop-filter: blur( 12px );
+				opacity: 0;
+				transition: opacity 0.25s ease;
+				pointer-events: auto;
+			}
+
+			.kk-track-select--visible {
+				opacity: 1;
+			}
+
+			/* ── Header bar ──────────────────────────────────────────── */
+
+			.kk-track-select__header {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				padding: var(--space-4, 1rem) var(--space-6, 1.5rem);
+				padding-top: calc( var(--space-4, 1rem) + 3.5rem );
+				border-bottom: 1px solid rgba( 255, 255, 255, 0.08 );
+			}
+
+			.kk-track-select__title {
+				font-family: var(--font-display, sans-serif);
+				font-size: var(--text-xl, 1.375rem);
+				font-weight: var(--weight-black, 900);
+				text-transform: uppercase;
+				letter-spacing: var(--tracking-wider, 0.1em);
+				color: var(--color-white, #fff);
+			}
+
+			.kk-track-select__back {
+				background: none;
+				border: none;
+				color: var(--color-ink-300, #aaa);
+				font-family: var(--font-ui, sans-serif);
+				font-size: var(--text-sm, 0.875rem);
+				font-weight: var(--weight-bold, 700);
+				text-transform: uppercase;
+				letter-spacing: var(--tracking-wider, 0.1em);
+				cursor: pointer;
+				padding: var(--space-2) var(--space-4);
+				transition: color 0.15s ease;
+			}
+
+			.kk-track-select__back:hover {
+				color: var(--color-white, #fff);
+			}
+
+			/* ── Browser area ────────────────────────────────────────── */
+
+			.kk-track-select__body {
+				flex: 1;
+				overflow-y: auto;
+				overflow-x: hidden;
+				padding: var(--space-4, 1rem);
+			}
+
+			/* ── Footer with GO button ───────────────────────────────── */
+
+			.kk-track-select__footer {
+				display: flex;
+				justify-content: center;
+				padding: var(--space-4, 1rem) var(--space-6, 1.5rem);
+				border-top: 1px solid rgba( 255, 255, 255, 0.08 );
+			}
+
+			.kk-track-select__footer .kk-hud-button {
+				min-width: 14rem;
+			}
+
+			@media ( prefers-reduced-motion: reduce ) {
+
+				.kk-track-select {
+					transition: none;
+				}
+
+			}
+
+		`;
+		document.head.appendChild( style );
+
+	}
+
+	// ---------------------------------------------------------------------------
+	// Show / Hide
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * Show the track selection overlay.
+	 *
+	 * @param {Function} onConfirm  Called with the resolved track data when GO is tapped.
+	 */
+	show( onConfirm ) {
+
+		this._onConfirm = onConfirm;
+
+		if ( this._overlay ) {
+
+			this._overlay.remove();
+
+		}
+
+		const overlay = document.createElement( 'div' );
+		overlay.className = 'kk-track-select';
+
+		// Header
+		const header = document.createElement( 'div' );
+		header.className = 'kk-track-select__header';
+
+		const title = document.createElement( 'div' );
+		title.className = 'kk-track-select__title';
+		title.textContent = 'SELECT TRACK';
+		header.appendChild( title );
+
+		const backBtn = document.createElement( 'button' );
+		backBtn.type = 'button';
+		backBtn.className = 'kk-track-select__back';
+		backBtn.textContent = 'BACK';
+		backBtn.addEventListener( 'click', () => this.hide() );
+		header.appendChild( backBtn );
+
+		overlay.appendChild( header );
+
+		// Body — TrackBrowser
+		const body = document.createElement( 'div' );
+		body.className = 'kk-track-select__body';
+
+		this._browser = new TrackBrowser( body, {
+			onTrackSelected: ( trackId ) => {
+
+				const settings = new Settings();
+				settings.setSelectedTrackId( trackId );
+
+			},
+			showManageActions: false,
+		} );
+
+		overlay.appendChild( body );
+
+		// Footer — GO button
+		const footer = document.createElement( 'div' );
+		footer.className = 'kk-track-select__footer';
+
+		this._goBtn = new HudButton( {
+			text:  'GO!',
+			color: '--color-accent-orange',
+			onClick: () => this._handleGo(),
+		} );
+
+		footer.appendChild( this._goBtn.el );
+		overlay.appendChild( footer );
+
+		this._overlay = overlay;
+		this._container.appendChild( overlay );
+
+		// Fade in
+		requestAnimationFrame( () => {
+
+			overlay.classList.add( 'kk-track-select--visible' );
+
+		} );
+
+	}
+
+	/**
+	 * Hide and clean up the overlay.
+	 */
+	hide() {
+
+		if ( ! this._overlay ) return;
+
+		this._overlay.classList.remove( 'kk-track-select--visible' );
+
+		// Remove after transition
+		setTimeout( () => {
+
+			if ( this._browser ) {
+
+				this._browser.dispose();
+				this._browser = null;
+
+			}
+
+			if ( this._goBtn ) {
+
+				this._goBtn.dispose();
+				this._goBtn = null;
+
+			}
+
+			if ( this._overlay && this._overlay.parentNode ) {
+
+				this._overlay.parentNode.removeChild( this._overlay );
+
+			}
+
+			this._overlay = null;
+			this._onConfirm = null;
+
+		}, 300 );
+
+	}
+
+	/**
+	 * Full cleanup.
+	 */
+	dispose() {
+
+		this.hide();
+
+	}
+
+	// ---------------------------------------------------------------------------
+	// Internal
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * Handle GO button tap — resolve selected track and call onConfirm.
+	 */
+	_handleGo() {
+
+		const track = this._resolveSelectedTrack();
+
+		if ( this._onConfirm ) {
+
+			this._onConfirm( track );
+
+		}
+
+		this.hide();
+
+	}
+
+	/**
+	 * Resolve the selected track from Settings.
+	 * Falls back to the first built-in track if the selected track is missing.
+	 *
+	 * @returns {{ name: string, cells: Array, decoCells: Array|undefined, source: string }}
+	 */
+	_resolveSelectedTrack() {
+
+		const settings = new Settings();
+		const trackId = settings.getSelectedTrackId();
+
+		// User-created track
+		if ( trackId && trackId.startsWith( 'user:' ) ) {
+
+			const trackName = trackId.slice( 5 );
+			const saved = getSavedTracks().find( ( t ) => t.name === trackName );
+
+			if ( saved ) {
+
+				return {
+					name:     saved.name,
+					cells:    decodeCells( saved.cells ),
+					decoCells: undefined,
+					source:   'custom',
+				};
+
+			}
+
+		}
+
+		// Built-in track
+		const builtIn = getTrackById( trackId );
+
+		if ( builtIn ) {
+
+			return {
+				name:     builtIn.name,
+				cells:    builtIn.cells,
+				decoCells: builtIn.decoCells,
+				source:   'official',
+			};
+
+		}
+
+		// Fallback
+		const fallback = getTracks()[ 0 ];
+
+		if ( ! fallback ) {
+
+			return { name: 'Unknown', cells: [], decoCells: undefined, source: 'fallback' };
+
+		}
+
+		return {
+			name:     fallback.name,
+			cells:    fallback.cells,
+			decoCells: fallback.decoCells,
+			source:   'official',
+		};
+
+	}
+
+}

--- a/js/ui/panels/RacePanel.js
+++ b/js/ui/panels/RacePanel.js
@@ -20,15 +20,13 @@
  *   dispose() — cleanup
  */
 
-import { HudButton }      from '../components/HudButton.js';
-import { TrackBrowser }   from '../components/TrackBrowser.js';
-import { LoadingOverlay }  from '../components/LoadingOverlay.js';
-import { LobbyOverlay }   from '../overlays/LobbyOverlay.js';
-import { Settings }        from '../../Settings.js';
-import { getRandomTrack, getTrackById, getTracks } from '../../TrackRegistry.js';
-import { decodeCells }     from '../../TrackCodec.js';
-import { getSavedTracks }  from '../../editor/Persistence.js';
-import { NetworkClient }   from '../../Network.js';
+import { HudButton }            from '../components/HudButton.js';
+import { LoadingOverlay }       from '../components/LoadingOverlay.js';
+import { LobbyOverlay }        from '../overlays/LobbyOverlay.js';
+import { TrackSelectOverlay }   from '../overlays/TrackSelectOverlay.js';
+import { Settings }             from '../../Settings.js';
+import { getRandomTrack }       from '../../TrackRegistry.js';
+import { NetworkClient }        from '../../Network.js';
 
 export class RacePanel {
 
@@ -58,11 +56,8 @@ export class RacePanel {
 		/** @type {HudButton | null} */
 		this._raceBtn = null;
 
-		/** @type {TrackBrowser | null} */
-		this._trackBrowser = null;
-
-		/** @type {HTMLElement | null} */
-		this._trackBrowserContainer = null;
+		/** @type {TrackSelectOverlay | null} */
+		this._trackSelectOverlay = null;
 
 		/** @type {Map<string, HTMLButtonElement>} */
 		this._chips = new Map();
@@ -84,24 +79,12 @@ export class RacePanel {
 		const style = document.createElement( 'style' );
 		style.textContent = `
 
-			/* ── PLAY screen root ──────────────────────────────────────── */
+			/* ── PLAY screen — minimal controls, bottom-right ─────────── */
 
 			.kk-race-panel {
 				position: absolute;
-				inset: 0;
-				display: flex;
-				align-items: flex-end;
-				justify-content: flex-end;
-				pointer-events: none;
-			}
-
-			.kk-race-panel > * {
-				pointer-events: auto;
-			}
-
-			/* ── Controls column (always visible, right-bottom) ────────── */
-
-			.kk-race-panel__controls {
+				bottom: 0;
+				right: 0;
 				display: flex;
 				flex-direction: column;
 				justify-content: flex-end;
@@ -109,35 +92,12 @@ export class RacePanel {
 				padding: var(--space-6);
 				padding-bottom: var(--space-8);
 				box-sizing: border-box;
+				pointer-events: none;
 				width: 240px;
 			}
 
-			/* ── Track browser container (hidden in RACE mode) ─────────── */
-
-			.kk-race-panel__browser {
-				display: none;
-				flex: 1;
-				overflow-y: auto;
-				overflow-x: hidden;
-				padding: var(--space-4);
-				box-sizing: border-box;
-				max-height: 100%;
-			}
-
-			.kk-race-panel--browse .kk-race-panel__browser {
-				display: block;
-			}
-
-			@media ( max-width: 768px ) {
-
-				.kk-race-panel--browse {
-					flex-direction: column;
-				}
-
-				.kk-race-panel--browse .kk-race-panel__controls {
-					width: 100%;
-				}
-
+			.kk-race-panel > * {
+				pointer-events: auto;
 			}
 
 			/* ── Mode chip strip ───────────────────────────────────────── */
@@ -270,26 +230,6 @@ export class RacePanel {
 		const root = document.createElement( 'div' );
 		root.className = 'kk-race-panel';
 
-		// Track browser container (hidden in RACE mode, visible in FREE PLAY / PARTY)
-		this._trackBrowserContainer = document.createElement( 'div' );
-		this._trackBrowserContainer.className = 'kk-race-panel__browser';
-
-		this._trackBrowser = new TrackBrowser( this._trackBrowserContainer, {
-			onTrackSelected: ( trackId ) => {
-
-				const settings = new Settings();
-				settings.setSelectedTrackId( trackId );
-
-			},
-			showManageActions: false,
-		} );
-
-		root.appendChild( this._trackBrowserContainer );
-
-		// Controls column (always visible — chip strip + PLAY button)
-		const controls = document.createElement( 'div' );
-		controls.className = 'kk-race-panel__controls';
-
 		// Mode chip strip
 		const chipStrip = document.createElement( 'div' );
 		chipStrip.className = 'kk-race-panel__chips';
@@ -310,7 +250,7 @@ export class RacePanel {
 
 		}
 
-		controls.appendChild( chipStrip );
+		root.appendChild( chipStrip );
 		this._chipStrip = chipStrip;
 
 		// PLAY button
@@ -324,7 +264,7 @@ export class RacePanel {
 		} );
 
 		ctaWrap.appendChild( this._raceBtn.el );
-		controls.appendChild( ctaWrap );
+		root.appendChild( ctaWrap );
 
 		// JOIN button (visible only in PARTY mode)
 		const joinBtn = document.createElement( 'button' );
@@ -333,13 +273,11 @@ export class RacePanel {
 		joinBtn.textContent = 'JOIN ROOM';
 		joinBtn.style.display = 'none';
 		joinBtn.addEventListener( 'click', () => this._handleJoinRoom() );
-		controls.appendChild( joinBtn );
+		root.appendChild( joinBtn );
 		this._joinBtn = joinBtn;
 
-		root.appendChild( controls );
-
 		this._updateChipStrip();
-		this._updateLayoutForMode();
+		this._updateJoinVisibility();
 
 		this._container.appendChild( root );
 		this._root = root;
@@ -361,33 +299,18 @@ export class RacePanel {
 
 		this._services.selectedMode = modeId;
 		this._updateChipStrip();
-		this._updateLayoutForMode();
+		this._updateJoinVisibility();
 
 	}
 
 	/**
-	 * Toggle the track browser visibility based on selected mode.
-	 * RACE (online): minimal — no track browser.
-	 * FREE PLAY (solo) / PARTY (private): show the track browser.
+	 * Show JOIN button only in PARTY mode.
 	 */
-	_updateLayoutForMode() {
+	_updateJoinVisibility() {
 
-		if ( ! this._root ) return;
-
-		const mode = this._services.selectedMode || 'solo';
-		const showBrowser = mode !== 'online';
-
-		this._root.classList.toggle( 'kk-race-panel--browse', showBrowser );
-
-		if ( showBrowser && this._trackBrowser ) {
-
-			this._trackBrowser.refresh();
-
-		}
-
-		// Show JOIN button only in PARTY mode
 		if ( this._joinBtn ) {
 
+			const mode = this._services.selectedMode || 'solo';
 			this._joinBtn.style.display = mode === 'private' ? '' : 'none';
 
 		}
@@ -425,7 +348,19 @@ export class RacePanel {
 		switch ( mode ) {
 
 			case 'solo':
-				this._startSoloRace();
+				this._openTrackSelect( ( track ) => {
+
+					const settings = new Settings();
+					const vehicleId = settings.getSelectedKartId();
+
+					this._services.startRace( {
+						mode:      'solo',
+						trackData: track.cells,
+						decoCells: track.decoCells,
+						vehicleId,
+					} );
+
+				} );
 				break;
 
 			case 'online':
@@ -433,90 +368,32 @@ export class RacePanel {
 				break;
 
 			case 'private':
-				await this._startPrivateLobby();
+				this._openTrackSelect( async ( track ) => {
+
+					await this._startPrivateLobby( track );
+
+				} );
 				break;
 
 		}
 
 	}
 
-	// ---------------------------------------------------------------------------
-	// Track card helpers
-	// ---------------------------------------------------------------------------
-
 	/**
-	 * Resolve the selected track from Settings. Returns { name, cells, decoCells, source }.
-	 * Falls back to the first built-in track if the selected track is missing.
+	 * Open the track selection overlay. Calls onConfirm(trackData) when the user picks a track.
+	 *
+	 * @param {Function} onConfirm  Callback with resolved track data.
 	 */
-	_resolveSelectedTrack() {
+	_openTrackSelect( onConfirm ) {
 
-		const settings = new Settings();
-		const trackId = settings.getSelectedTrackId();
+		if ( ! this._trackSelectOverlay ) {
 
-		// User-created track
-		if ( trackId && trackId.startsWith( 'user:' ) ) {
-
-			const trackName = trackId.slice( 5 );
-			const saved = getSavedTracks().find( ( t ) => t.name === trackName );
-
-			if ( saved ) {
-
-				return {
-					name:     saved.name,
-					cells:    decodeCells( saved.cells ),
-					decoCells: undefined,
-					source:   'custom',
-				};
-
-			}
-
-			// Deleted track — fall through to default
+			const shell = this._container.closest( '#kk-app-shell' ) || document.body;
+			this._trackSelectOverlay = new TrackSelectOverlay( shell, this._services );
 
 		}
 
-		// Built-in track
-		const builtIn = getTrackById( trackId );
-
-		if ( builtIn ) {
-
-			return {
-				name:     builtIn.name,
-				cells:    builtIn.cells,
-				decoCells: builtIn.decoCells,
-				source:   'official',
-			};
-
-		}
-
-		// Fallback
-		const fallback = getTracks()[ 0 ];
-
-		return {
-			name:     fallback.name,
-			cells:    fallback.cells,
-			decoCells: fallback.decoCells,
-			source:   'official',
-		};
-
-	}
-
-
-	// ---------------------------------------------------------------------------
-	// SOLO race
-	// ---------------------------------------------------------------------------
-
-	_startSoloRace() {
-
-		const settings = new Settings();
-		const vehicleId = settings.getSelectedKartId();
-		const track = this._resolveSelectedTrack();
-
-		this._services.startRace( {
-			mode:      'solo',
-			trackData: track.cells,
-			decoCells: track.decoCells,
-			vehicleId,
-		} );
+		this._trackSelectOverlay.show( onConfirm );
 
 	}
 
@@ -610,9 +487,12 @@ export class RacePanel {
 	// PRIVATE lobby
 	// ---------------------------------------------------------------------------
 
-	async _startPrivateLobby() {
+	/**
+	 * @param {object} track  Resolved track data from TrackSelectOverlay.
+	 */
+	async _startPrivateLobby( track ) {
 
-		// Create a NetworkClient on demand (same pattern as online matchmaking).
+		// Create a NetworkClient on demand.
 		if ( ! this._network ) {
 
 			this._network = new NetworkClient();
@@ -622,13 +502,10 @@ export class RacePanel {
 		// Create LobbyOverlay if needed.
 		if ( ! this._lobbyOverlay ) {
 
-			// Mount into the shell element (parent of our container).
 			const shell = this._container.closest( '#kk-app-shell' ) || document.body;
 			this._lobbyOverlay = new LobbyOverlay( shell, this._services );
 
 		}
-
-		const track = this._resolveSelectedTrack();
 
 		this._lobbyOverlay.show( this._network, { trackData: track, isHost: true } );
 
@@ -754,11 +631,9 @@ export class RacePanel {
 	 */
 	show() {
 
-		// Sync chip strip with services bag
+		// Sync chip strip and JOIN button with services bag
 		this._updateChipStrip();
-
-		// Toggle layout and refresh track browser
-		this._updateLayoutForMode();
+		this._updateJoinVisibility();
 
 	}
 
@@ -810,15 +685,14 @@ export class RacePanel {
 
 		}
 
-		if ( this._trackBrowser ) {
+		if ( this._trackSelectOverlay ) {
 
-			this._trackBrowser.dispose();
-			this._trackBrowser = null;
+			this._trackSelectOverlay.dispose();
+			this._trackSelectOverlay = null;
 
 		}
 
 		this._root = null;
-		this._trackBrowserContainer = null;
 		this._chips.clear();
 		this._chipStrip = null;
 		this._joinBtn = null;

--- a/js/ui/panels/TracksPanel.js
+++ b/js/ui/panels/TracksPanel.js
@@ -331,8 +331,6 @@ export class TracksPanel {
 		this._browser.show();
 		this._reappendCreateCard();
 
-		}
-
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Moves track selection from inline on the PLAY screen to a full-screen overlay that opens after pressing PLAY in FREE PLAY or PARTY mode. This completes the race mode flow restructure: PLAY screen stays minimal for all modes, track browsing is its own dedicated step.

## What changed

- **TrackSelectOverlay** — new full-screen overlay with TrackBrowser, GO button, BACK button. Opens after PLAY in FREE PLAY/PARTY modes
- **RacePanel simplified** — removed inline TrackBrowser and dynamic layout toggle. Now just chip strip + PLAY + JOIN for all modes
- **TracksPanel syntax fix** — extra closing brace from earlier edit

## Mode flows (final)

| Mode | Flow |
|------|------|
| RACE | PLAY → matchmaking → race |
| FREE PLAY | PLAY → track select overlay → GO → race |
| PARTY | PLAY → track select overlay → GO → lobby |

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: client-side UI refactor only, no server changes in this PR.

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)